### PR TITLE
Nathan's changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-logs
+logs/
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use our Tethyscore base docker image as a parent image
-FROM tethysplatform/tethys-core:master
+FROM tethysplatform/tethys-core:3.4.1
 
 #########
 # SETUP #
@@ -52,10 +52,10 @@ RUN /bin/bash -c ". ${CONDA_HOME}/bin/activate tethys \
   ; cd /tethys_apps/reservoirs \
   ; tethys install -N"
 
-RUN ${CONDA_HOME}/bin/conda install -n tethys pip
+# RUN ${CONDA_HOME}/bin/conda install -n tethys pip
 
-RUN /bin/bash -c ". ${CONDA_HOME}/bin/activate tethys \
-  ;  pip install psycopg2==2.8.6"
+# RUN /bin/bash -c ". ${CONDA_HOME}/bin/activate tethys \
+#   ;  pip install psycopg2==2.8.6"
 
 ######################################################
 # CHANGE THE PROXY TIME REPLACING THE NGINX TEMPLATE #
@@ -91,7 +91,7 @@ EXPOSE 80
 ################
 
 ## Be sure to be inside the docker_files folder ##
-ADD /salt/ /srv/salt/
+ADD salt/ /srv/salt/
 
 #####################################
 # ADDITIONAL DATABASE CONFIGURATION #
@@ -109,4 +109,4 @@ ADD final_run.sh $HOME
 #######
 # RUN #
 #######
-CMD bash final_run.sh
+CMD bash run.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ./data/tethys:/var/lib/tethys_persist
       - ./logs/tethys:/var/log/tethys
   db:
-    image: postgres
+    image: postgis/postgis:latest
     restart: always
     volumes:
       - ./data/db:/var/lib/postgresql/data

--- a/env/web.env
+++ b/env/web.env
@@ -1,10 +1,12 @@
 # Domain name of server should be first in the list if multiple entries added
-ALLOWED_HOSTS="\"[localhost]\""
+ALLOWED_HOSTS="\"\[localhost, 127.0.0.1\]\""
 
 # Don't change these parameters
 ASGI_PROCESSES=1
 CHANNEL_LAYERS_BACKEND=channels_redis.core.RedisChannelLayer
-CHANNEL_LAYERS_CONFIG="\"{\"hosts\": [[\"redis\", 6379]]}\""  # Hostname is the name of the service
+CHANNEL_LAYERS_CONFIG="\"\{\"hosts\":\[\[\"redis\",6379\]\]\}\""  # Hostname is the name of the service
+
+
 CLIENT_MAX_BODY_SIZE=100M
 BYPASS_TETHYS_HOME_PAGE=True
 ENABLE_OPEN_PORTAL=True

--- a/web.logs
+++ b/web.logs
@@ -1,0 +1,3298 @@
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | - Starting up...
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | - Checking if DB is ready
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | db:5432 - no response
+docker_portal-web-1  | DB is unavailable - sleeping
+docker_portal-web-1  | db:5432 - no response
+docker_portal-web-1  | DB is unavailable - sleeping
+docker_portal-web-1  | db:5432 - no response
+docker_portal-web-1  | DB is unavailable - sleeping
+docker_portal-web-1  | db:5432 - no response
+docker_portal-web-1  | DB is unavailable - sleeping
+docker_portal-web-1  | db:5432 - accepting connections
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | - Enforcing start state... (This might take a bit)
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | [ERROR   ] Command '/opt/conda/envs/tethys/bin/tethys' failed with return code: 2
+docker_portal-web-1  | [ERROR   ] stderr: usage: tethys [-h]
+docker_portal-web-1  |               {version,app_settings,db,docker,gen,install,uninstall,link,list,manage,scaffold,schedulers,services,settings,site,syncstores,test}
+docker_portal-web-1  |               ...
+docker_portal-web-1  | tethys: error: unrecognized arguments: CAPTCHA_CONFIG.RECAPTCHA_PRIVATE_KEY
+docker_portal-web-1  | [ERROR   ] retcode: 2
+docker_portal-web-1  | [ERROR   ] {'pid': 123, 'retcode': 2, 'stdout': '', 'stderr': 'usage: tethys [-h]\n              {version,app_settings,db,docker,gen,install,uninstall,link,list,manage,scaffold,schedulers,services,settings,site,syncstores,test}\n              ...\ntethys: error: unrecognized arguments: CAPTCHA_CONFIG.RECAPTCHA_PRIVATE_KEY'}
+docker_portal-web-1  | [ERROR   ] Command '.' failed with return code: 2
+docker_portal-web-1  | [ERROR   ] stdout: [34mCreating Tethys database user "tethys_super"...[0m
+docker_portal-web-1  | [31mFailed to create Tethys database user for "tethys_super"[0m
+docker_portal-web-1  | [ERROR   ] stderr: psql: error: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | [ERROR   ] retcode: 2
+docker_portal-web-1  | [ERROR   ] {'pid': 182, 'retcode': 2, 'stdout': '\x1b[34mCreating Tethys database user "tethys_super"...\x1b[0m\n\x1b[31mFailed to create Tethys database user for "tethys_super"\x1b[0m', 'stderr': 'psql: error: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?'}
+docker_portal-web-1  | [ERROR   ] Command '.' failed with return code: 1
+docker_portal-web-1  | [ERROR   ] stdout: [34mRunning migrations for Tethys database...[0m
+docker_portal-web-1  | [31mERROR!!![0m
+docker_portal-web-1  | [ERROR   ] stderr: Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | 
+docker_portal-web-1  | 
+docker_portal-web-1  | The above exception was the direct cause of the following exception:
+docker_portal-web-1  | 
+docker_portal-web-1  | Traceback (most recent call last):
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_portal/manage.py", line 20, in <module>
+docker_portal-web-1  |     execute_from_command_line(sys.argv)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
+docker_portal-web-1  |     utility.execute()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 357, in execute
+docker_portal-web-1  |     django.setup()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |     apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |     app_config.ready()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |     self.module.autodiscover()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |     autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |     import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |     return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |     from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |     register_custom_group()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |     class CustomGroup(GroupAdmin):
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |     form = make_gop_app_access_form()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |     for app_qs in all_apps:
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |     self._fetch_all()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |     self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |     results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |     cursor = self.connection.cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |     return self._cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |     self.ensure_connection()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |     raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | [ERROR   ] retcode: 1
+docker_portal-web-1  | [ERROR   ] {'pid': 201, 'retcode': 1, 'stdout': '\x1b[34mRunning migrations for Tethys database...\x1b[0m\n\x1b[31mERROR!!!\x1b[0m', 'stderr': 'Traceback (most recent call last):\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\npsycopg2.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?\n\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File "/usr/lib/tethys/tethys/tethys_portal/manage.py", line 20, in <module>\n    execute_from_command_line(sys.argv)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line\n    utility.execute()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 357, in execute\n    django.setup()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup\n    apps.populate(settings.INSTALLED_APPS)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate\n    app_config.ready()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready\n    self.module.autodiscover()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover\n    autodiscover_modules(\'admin\', register_to=site)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules\n    import_module(\'%s.%s\' % (app_config.name, module_to_search))\n  File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import\n  File "<frozen importlib._bootstrap>", line 983, in _find_and_load\n  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked\n  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked\n  File "<frozen importlib._bootstrap_external>", line 728, in exec_module\n  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed\n  File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>\n    from tethys_apps.admin import TethysAppSettingInline\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>\n    register_custom_group()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group\n    class CustomGroup(GroupAdmin):\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup\n    form = make_gop_app_access_form()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form\n    for app_qs in all_apps:\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__\n    self._fetch_all()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all\n    self._result_cache = list(self._iterable_class(self))\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__\n    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql\n    cursor = self.connection.cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor\n    return self._cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor\n    self.ensure_connection()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__\n    raise dj_exc_value.with_traceback(traceback) from exc_value\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\ndjango.db.utils.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?'}
+docker_portal-web-1  | [ERROR   ] Command '.' failed with return code: 1
+docker_portal-web-1  | [ERROR   ] stdout: [34mCreating Tethys Portal superuser "admin"...[0m
+docker_portal-web-1  | [ERROR   ] stderr: Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | 
+docker_portal-web-1  | 
+docker_portal-web-1  | The above exception was the direct cause of the following exception:
+docker_portal-web-1  | 
+docker_portal-web-1  | Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |     sys.exit(tethys_command())
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |     args.func(args)
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/db_commands.py", line 385, in db_command
+docker_portal-web-1  |     DB_COMMANDS[args.command](**options)
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/db_commands.py", line 295, in create_portal_superuser
+docker_portal-web-1  |     load_apps()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |     django.setup()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |     apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |     app_config.ready()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |     self.module.autodiscover()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |     autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |     import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |     return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |     from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |     register_custom_group()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |     class CustomGroup(GroupAdmin):
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |     form = make_gop_app_access_form()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |     for app_qs in all_apps:
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |     self._fetch_all()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |     self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |     results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |     cursor = self.connection.cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |     return self._cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |     self.ensure_connection()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |     raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | [ERROR   ] retcode: 1
+docker_portal-web-1  | [ERROR   ] {'pid': 229, 'retcode': 1, 'stdout': '\x1b[34mCreating Tethys Portal superuser "admin"...\x1b[0m', 'stderr': 'Traceback (most recent call last):\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\npsycopg2.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?\n\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>\n    sys.exit(tethys_command())\n  File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command\n    args.func(args)\n  File "/usr/lib/tethys/tethys/tethys_cli/db_commands.py", line 385, in db_command\n    DB_COMMANDS[args.command](**options)\n  File "/usr/lib/tethys/tethys/tethys_cli/db_commands.py", line 295, in create_portal_superuser\n    load_apps()\n  File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps\n    django.setup()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup\n    apps.populate(settings.INSTALLED_APPS)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate\n    app_config.ready()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready\n    self.module.autodiscover()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover\n    autodiscover_modules(\'admin\', register_to=site)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules\n    import_module(\'%s.%s\' % (app_config.name, module_to_search))\n  File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import\n  File "<frozen importlib._bootstrap>", line 983, in _find_and_load\n  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked\n  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked\n  File "<frozen importlib._bootstrap_external>", line 728, in exec_module\n  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed\n  File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>\n    from tethys_apps.admin import TethysAppSettingInline\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>\n    register_custom_group()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group\n    class CustomGroup(GroupAdmin):\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup\n    form = make_gop_app_access_form()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form\n    for app_qs in all_apps:\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__\n    self._fetch_all()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all\n    self._result_cache = list(self._iterable_class(self))\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__\n    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql\n    cursor = self.connection.cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor\n    return self._cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor\n    self.ensure_connection()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__\n    raise dj_exc_value.with_traceback(traceback) from exc_value\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\ndjango.db.utils.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?'}
+docker_portal-web-1  | [ERROR   ] Command '.' failed with return code: 1
+docker_portal-web-1  | [ERROR   ] stderr: Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | 
+docker_portal-web-1  | 
+docker_portal-web-1  | The above exception was the direct cause of the following exception:
+docker_portal-web-1  | 
+docker_portal-web-1  | Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |     sys.exit(tethys_command())
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |     args.func(args)
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/services_commands.py", line 170, in services_create_spatial_command
+docker_portal-web-1  |     load_apps()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |     django.setup()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |     apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |     app_config.ready()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |     self.module.autodiscover()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |     autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |     import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |     return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |     from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |     register_custom_group()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |     class CustomGroup(GroupAdmin):
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |     form = make_gop_app_access_form()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |     for app_qs in all_apps:
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |     self._fetch_all()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |     self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |     results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |     cursor = self.connection.cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |     return self._cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |     self.ensure_connection()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |     raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | [ERROR   ] retcode: 1
+docker_portal-web-1  | [ERROR   ] {'pid': 248, 'retcode': 1, 'stdout': '', 'stderr': 'Traceback (most recent call last):\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\npsycopg2.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?\n\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>\n    sys.exit(tethys_command())\n  File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command\n    args.func(args)\n  File "/usr/lib/tethys/tethys/tethys_cli/services_commands.py", line 170, in services_create_spatial_command\n    load_apps()\n  File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps\n    django.setup()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup\n    apps.populate(settings.INSTALLED_APPS)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate\n    app_config.ready()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready\n    self.module.autodiscover()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover\n    autodiscover_modules(\'admin\', register_to=site)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules\n    import_module(\'%s.%s\' % (app_config.name, module_to_search))\n  File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import\n  File "<frozen importlib._bootstrap>", line 983, in _find_and_load\n  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked\n  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked\n  File "<frozen importlib._bootstrap_external>", line 728, in exec_module\n  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed\n  File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>\n    from tethys_apps.admin import TethysAppSettingInline\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>\n    register_custom_group()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group\n    class CustomGroup(GroupAdmin):\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup\n    form = make_gop_app_access_form()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form\n    for app_qs in all_apps:\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__\n    self._fetch_all()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all\n    self._result_cache = list(self._iterable_class(self))\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__\n    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql\n    cursor = self.connection.cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor\n    return self._cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor\n    self.ensure_connection()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__\n    raise dj_exc_value.with_traceback(traceback) from exc_value\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\ndjango.db.utils.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?'}
+docker_portal-web-1  | [ERROR   ] Command '.' failed with return code: 1
+docker_portal-web-1  | [ERROR   ] stderr: Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | 
+docker_portal-web-1  | 
+docker_portal-web-1  | The above exception was the direct cause of the following exception:
+docker_portal-web-1  | 
+docker_portal-web-1  | Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |     sys.exit(tethys_command())
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |     args.func(args)
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/services_commands.py", line 170, in services_create_spatial_command
+docker_portal-web-1  |     load_apps()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |     django.setup()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |     apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |     app_config.ready()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |     self.module.autodiscover()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |     autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |     import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |     return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |     from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |     register_custom_group()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |     class CustomGroup(GroupAdmin):
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |     form = make_gop_app_access_form()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |     for app_qs in all_apps:
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |     self._fetch_all()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |     self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |     results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |     cursor = self.connection.cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |     return self._cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |     self.ensure_connection()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |     raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | [ERROR   ] retcode: 1
+docker_portal-web-1  | [ERROR   ] {'pid': 266, 'retcode': 1, 'stdout': '', 'stderr': 'Traceback (most recent call last):\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\npsycopg2.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?\n\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>\n    sys.exit(tethys_command())\n  File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command\n    args.func(args)\n  File "/usr/lib/tethys/tethys/tethys_cli/services_commands.py", line 170, in services_create_spatial_command\n    load_apps()\n  File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps\n    django.setup()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup\n    apps.populate(settings.INSTALLED_APPS)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate\n    app_config.ready()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready\n    self.module.autodiscover()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover\n    autodiscover_modules(\'admin\', register_to=site)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules\n    import_module(\'%s.%s\' % (app_config.name, module_to_search))\n  File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import\n  File "<frozen importlib._bootstrap>", line 983, in _find_and_load\n  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked\n  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked\n  File "<frozen importlib._bootstrap_external>", line 728, in exec_module\n  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed\n  File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>\n    from tethys_apps.admin import TethysAppSettingInline\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>\n    register_custom_group()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group\n    class CustomGroup(GroupAdmin):\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup\n    form = make_gop_app_access_form()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form\n    for app_qs in all_apps:\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__\n    self._fetch_all()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all\n    self._result_cache = list(self._iterable_class(self))\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__\n    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql\n    cursor = self.connection.cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor\n    return self._cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor\n    self.ensure_connection()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__\n    raise dj_exc_value.with_traceback(traceback) from exc_value\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\ndjango.db.utils.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?'}
+docker_portal-web-1  | [ERROR   ] Command '.' failed with return code: 1
+docker_portal-web-1  | [ERROR   ] stderr: Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | 
+docker_portal-web-1  | 
+docker_portal-web-1  | The above exception was the direct cause of the following exception:
+docker_portal-web-1  | 
+docker_portal-web-1  | Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |     sys.exit(tethys_command())
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |     args.func(args)
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/services_commands.py", line 134, in services_create_persistent_command
+docker_portal-web-1  |     load_apps()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |     django.setup()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |     apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |     app_config.ready()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |     self.module.autodiscover()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |     autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |     import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |     return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |     from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |     register_custom_group()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |     class CustomGroup(GroupAdmin):
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |     form = make_gop_app_access_form()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |     for app_qs in all_apps:
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |     self._fetch_all()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |     self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |     results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |     cursor = self.connection.cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |     return self._cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |     self.ensure_connection()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |     raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | [ERROR   ] retcode: 1
+docker_portal-web-1  | [ERROR   ] {'pid': 284, 'retcode': 1, 'stdout': '', 'stderr': 'Traceback (most recent call last):\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\npsycopg2.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?\n\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>\n    sys.exit(tethys_command())\n  File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command\n    args.func(args)\n  File "/usr/lib/tethys/tethys/tethys_cli/services_commands.py", line 134, in services_create_persistent_command\n    load_apps()\n  File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps\n    django.setup()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup\n    apps.populate(settings.INSTALLED_APPS)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate\n    app_config.ready()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready\n    self.module.autodiscover()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover\n    autodiscover_modules(\'admin\', register_to=site)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules\n    import_module(\'%s.%s\' % (app_config.name, module_to_search))\n  File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import\n  File "<frozen importlib._bootstrap>", line 983, in _find_and_load\n  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked\n  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked\n  File "<frozen importlib._bootstrap_external>", line 728, in exec_module\n  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed\n  File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>\n    from tethys_apps.admin import TethysAppSettingInline\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>\n    register_custom_group()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group\n    class CustomGroup(GroupAdmin):\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup\n    form = make_gop_app_access_form()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form\n    for app_qs in all_apps:\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__\n    self._fetch_all()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all\n    self._result_cache = list(self._iterable_class(self))\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__\n    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql\n    cursor = self.connection.cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor\n    return self._cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor\n    self.ensure_connection()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__\n    raise dj_exc_value.with_traceback(traceback) from exc_value\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\ndjango.db.utils.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?'}
+docker_portal-web-1  | [ERROR   ] Command '.' failed with return code: 1
+docker_portal-web-1  | [ERROR   ] stdout: [34mSyncing the Tethys database with installed apps and extensions...[0m
+docker_portal-web-1  | [ERROR   ] stderr: Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | 
+docker_portal-web-1  | 
+docker_portal-web-1  | The above exception was the direct cause of the following exception:
+docker_portal-web-1  | 
+docker_portal-web-1  | Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |     sys.exit(tethys_command())
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |     args.func(args)
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/db_commands.py", line 385, in db_command
+docker_portal-web-1  |     DB_COMMANDS[args.command](**options)
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/db_commands.py", line 278, in sync_tethys_apps_db
+docker_portal-web-1  |     load_apps()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |     django.setup()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |     apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |     app_config.ready()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |     self.module.autodiscover()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |     autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |     import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |     return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |     from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |     register_custom_group()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |     class CustomGroup(GroupAdmin):
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |     form = make_gop_app_access_form()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |     for app_qs in all_apps:
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |     self._fetch_all()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |     self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |     results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |     cursor = self.connection.cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |     return self._cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |     self.ensure_connection()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |     raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | [ERROR   ] retcode: 1
+docker_portal-web-1  | [ERROR   ] {'pid': 304, 'retcode': 1, 'stdout': '\x1b[34mSyncing the Tethys database with installed apps and extensions...\x1b[0m', 'stderr': 'Traceback (most recent call last):\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\npsycopg2.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?\n\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>\n    sys.exit(tethys_command())\n  File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command\n    args.func(args)\n  File "/usr/lib/tethys/tethys/tethys_cli/db_commands.py", line 385, in db_command\n    DB_COMMANDS[args.command](**options)\n  File "/usr/lib/tethys/tethys/tethys_cli/db_commands.py", line 278, in sync_tethys_apps_db\n    load_apps()\n  File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps\n    django.setup()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup\n    apps.populate(settings.INSTALLED_APPS)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate\n    app_config.ready()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready\n    self.module.autodiscover()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover\n    autodiscover_modules(\'admin\', register_to=site)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules\n    import_module(\'%s.%s\' % (app_config.name, module_to_search))\n  File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import\n  File "<frozen importlib._bootstrap>", line 983, in _find_and_load\n  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked\n  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked\n  File "<frozen importlib._bootstrap_external>", line 728, in exec_module\n  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed\n  File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>\n    from tethys_apps.admin import TethysAppSettingInline\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>\n    register_custom_group()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group\n    class CustomGroup(GroupAdmin):\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup\n    form = make_gop_app_access_form()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form\n    for app_qs in all_apps:\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__\n    self._fetch_all()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all\n    self._result_cache = list(self._iterable_class(self))\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__\n    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql\n    cursor = self.connection.cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor\n    return self._cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor\n    self.ensure_connection()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__\n    raise dj_exc_value.with_traceback(traceback) from exc_value\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\ndjango.db.utils.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?'}
+docker_portal-web-1  | [ERROR   ] Command '.' failed with return code: 1
+docker_portal-web-1  | [ERROR   ] stderr: Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | 
+docker_portal-web-1  | 
+docker_portal-web-1  | The above exception was the direct cause of the following exception:
+docker_portal-web-1  | 
+docker_portal-web-1  | Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |     sys.exit(tethys_command())
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |     args.func(args)
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/app_settings_commands.py", line 121, in app_settings_set_command
+docker_portal-web-1  |     load_apps()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |     django.setup()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |     apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |     app_config.ready()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |     self.module.autodiscover()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |     autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |     import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |     return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |     from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |     register_custom_group()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |     class CustomGroup(GroupAdmin):
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |     form = make_gop_app_access_form()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |     for app_qs in all_apps:
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |     self._fetch_all()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |     self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |     results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |     cursor = self.connection.cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |     return self._cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |     self.ensure_connection()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |     raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | [ERROR   ] retcode: 1
+docker_portal-web-1  | [ERROR   ] {'pid': 329, 'retcode': 1, 'stdout': '', 'stderr': 'Traceback (most recent call last):\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\npsycopg2.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?\n\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>\n    sys.exit(tethys_command())\n  File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command\n    args.func(args)\n  File "/usr/lib/tethys/tethys/tethys_cli/app_settings_commands.py", line 121, in app_settings_set_command\n    load_apps()\n  File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps\n    django.setup()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup\n    apps.populate(settings.INSTALLED_APPS)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate\n    app_config.ready()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready\n    self.module.autodiscover()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover\n    autodiscover_modules(\'admin\', register_to=site)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules\n    import_module(\'%s.%s\' % (app_config.name, module_to_search))\n  File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import\n  File "<frozen importlib._bootstrap>", line 983, in _find_and_load\n  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked\n  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked\n  File "<frozen importlib._bootstrap_external>", line 728, in exec_module\n  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed\n  File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>\n    from tethys_apps.admin import TethysAppSettingInline\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>\n    register_custom_group()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group\n    class CustomGroup(GroupAdmin):\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup\n    form = make_gop_app_access_form()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form\n    for app_qs in all_apps:\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__\n    self._fetch_all()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all\n    self._result_cache = list(self._iterable_class(self))\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__\n    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql\n    cursor = self.connection.cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor\n    return self._cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor\n    self.ensure_connection()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__\n    raise dj_exc_value.with_traceback(traceback) from exc_value\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\ndjango.db.utils.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?'}
+docker_portal-web-1  | [ERROR   ] Command '.' failed with return code: 2
+docker_portal-web-1  | [ERROR   ] stderr: /bin/bash: -c: line 2: syntax error: unexpected end of file
+docker_portal-web-1  | [ERROR   ] retcode: 2
+docker_portal-web-1  | [ERROR   ] {'pid': 348, 'retcode': 2, 'stdout': '', 'stderr': '/bin/bash: -c: line 2: syntax error: unexpected end of file'}
+docker_portal-web-1  | [ERROR   ] Command '.' failed with return code: 1
+docker_portal-web-1  | [ERROR   ] stderr: Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | 
+docker_portal-web-1  | 
+docker_portal-web-1  | The above exception was the direct cause of the following exception:
+docker_portal-web-1  | 
+docker_portal-web-1  | Traceback (most recent call last):
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |     sys.exit(tethys_command())
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |     args.func(args)
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/site_commands.py", line 184, in gen_site_content
+docker_portal-web-1  |     load_apps()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |     django.setup()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |     apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |     app_config.ready()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |     self.module.autodiscover()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |     autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |     import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |     return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |     from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |     register_custom_group()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |     class CustomGroup(GroupAdmin):
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |     form = make_gop_app_access_form()
+docker_portal-web-1  |   File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |     for app_qs in all_apps:
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |     self._fetch_all()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |     self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |     results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |     cursor = self.connection.cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |     return self._cursor()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |     self.ensure_connection()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |     raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |     self.connect()
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |     self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |     connection = Database.connect(**conn_params)
+docker_portal-web-1  |   File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  | django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  | 	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | could not connect to server: Cannot assign requested address
+docker_portal-web-1  | 	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  | 	TCP/IP connections on port 5436?
+docker_portal-web-1  | [ERROR   ] retcode: 1
+docker_portal-web-1  | [ERROR   ] {'pid': 382, 'retcode': 1, 'stdout': '', 'stderr': 'Traceback (most recent call last):\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\npsycopg2.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?\n\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>\n    sys.exit(tethys_command())\n  File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command\n    args.func(args)\n  File "/usr/lib/tethys/tethys/tethys_cli/site_commands.py", line 184, in gen_site_content\n    load_apps()\n  File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps\n    django.setup()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup\n    apps.populate(settings.INSTALLED_APPS)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate\n    app_config.ready()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready\n    self.module.autodiscover()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover\n    autodiscover_modules(\'admin\', register_to=site)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules\n    import_module(\'%s.%s\' % (app_config.name, module_to_search))\n  File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import\n  File "<frozen importlib._bootstrap>", line 983, in _find_and_load\n  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked\n  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked\n  File "<frozen importlib._bootstrap_external>", line 728, in exec_module\n  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed\n  File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>\n    from tethys_apps.admin import TethysAppSettingInline\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>\n    register_custom_group()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group\n    class CustomGroup(GroupAdmin):\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup\n    form = make_gop_app_access_form()\n  File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form\n    for app_qs in all_apps:\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__\n    self._fetch_all()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all\n    self._result_cache = list(self._iterable_class(self))\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__\n    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql\n    cursor = self.connection.cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor\n    return self._cursor()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor\n    self.ensure_connection()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__\n    raise dj_exc_value.with_traceback(traceback) from exc_value\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection\n    self.connect()\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect\n    self.connection = self.get_new_connection(conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection\n    connection = Database.connect(**conn_params)\n  File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\ndjango.db.utils.OperationalError: could not connect to server: Connection refused\n\tIs the server running on host "localhost" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5436?\ncould not connect to server: Cannot assign requested address\n\tIs the server running on host "localhost" (::1) and accepting\n\tTCP/IP connections on port 5436?'}
+docker_portal-web-1  | local:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Create_Static_Root_On_Mounted_Pre_Tethys
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: mkdir -p /var/lib/tethys_persist/static
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command "mkdir -p /var/lib/tethys_persist/static" run
+docker_portal-web-1  |      Started: 20:42:11.224974
+docker_portal-web-1  |     Duration: 2535.175 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   107
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Create_Workspace_Root_On_Mounted_Pre_Tethys
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: mkdir -p /var/lib/tethys_persist/workspaces
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command "mkdir -p /var/lib/tethys_persist/workspaces" run
+docker_portal-web-1  |      Started: 20:42:13.760554
+docker_portal-web-1  |     Duration: 42.108 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   109
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Chown_Static_Workspaces_On_Mounted_Pre_Tethys
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: export NGINX_USER=$(grep 'user .*;' /etc/nginx/nginx.conf | awk '{print $2}' | awk -F';' '{print $1}') ; find /var/lib/tethys_persist/workspaces ! -user ${NGINX_USER} -print0 | xargs -0 -I{} chown ${NGINX_USER}: {} ; find /var/lib/tethys_persist/static ! -user ${NGINX_USER} -print0 | xargs -0 -I{} chown ${NGINX_USER}: {}
+docker_portal-web-1  | 
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command "export NGINX_USER=$(grep 'user .*;' /etc/nginx/nginx.conf | awk '{print $2}' | awk -F';' '{print $1}') ; find /var/lib/tethys_persist/workspaces ! -user ${NGINX_USER} -print0 | xargs -0 -I{} chown ${NGINX_USER}: {} ; find /var/lib/tethys_persist/static ! -user ${NGINX_USER} -print0 | xargs -0 -I{} chown ${NGINX_USER}: {}
+docker_portal-web-1  |               " run
+docker_portal-web-1  |      Started: 20:42:13.803125
+docker_portal-web-1  |     Duration: 63.547 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   110
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: ~/.bashrc
+docker_portal-web-1  |     Function: file.append
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Appended 1 lines
+docker_portal-web-1  |      Started: 20:42:13.867175
+docker_portal-web-1  |     Duration: 33.123 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               diff:
+docker_portal-web-1  |                   --- 
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   +++ 
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   @@ -18,3 +18,4 @@
+docker_portal-web-1  |                   
+docker_portal-web-1  |                    # alias mv='mv -i'
+docker_portal-web-1  |                    . /opt/conda/etc/profile.d/conda.sh
+docker_portal-web-1  |                    conda activate base
+docker_portal-web-1  |                   +alias t='. /opt/conda/bin/activate tethys'
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Generate_Tethys_Settings_TethysCore
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: /opt/conda/envs/tethys/bin/tethys settings --set DEBUG False --set ALLOWED_HOSTS "[localhost, 127.0.0.1]\ --set DATABASES.default.NAME tethys_platform --set DATABASES.default.USER tethys_default --set DATABASES.default.PASSWORD pass --set DATABASES.default.HOST db --set DATABASES.default.PORT 5432 --set INSTALLED_APPS "[]" --set SESSION_CONFIG.SECURITY_WARN_AFTER 1500 --set SESSION_CONFIG.SECURITY_EXPIRE_AFTER 1800 --set TETHYS_PORTAL_CONFIG.STATIC_ROOT /var/lib/tethys_persist/static --set TETHYS_PORTAL_CONFIG.TETHYS_WORKSPACES_ROOT /var/lib/tethys_persist/workspaces --set RESOURCE_QUOTA_HANDLERS "[]" --set ANALYTICS_CONFIG "{}" --set AUTHENTICATION_BACKENDS "[]" --set OAUTH_CONFIG "{}" --set CHANNEL_LAYERS.default.BACKEND channels_redis.core.RedisChannelLayer --set CHANNEL_LAYERS.default.CONFIG "{"hosts":[["redis",6379]]}\ --set CAPTCHA_CONFIG.RECAPTCHA_PRIVATE_KEY '' --set CAPTCHA_CONFIG.RECAPTCHA_PUBLIC_KEY ''
+docker_portal-web-1  | 
+docker_portal-web-1  |       Result: False
+docker_portal-web-1  |      Comment: Command "/opt/conda/envs/tethys/bin/tethys settings --set DEBUG False --set ALLOWED_HOSTS "[localhost, 127.0.0.1]\ --set DATABASES.default.NAME tethys_platform --set DATABASES.default.USER tethys_default --set DATABASES.default.PASSWORD pass --set DATABASES.default.HOST db --set DATABASES.default.PORT 5432 --set INSTALLED_APPS "[]" --set SESSION_CONFIG.SECURITY_WARN_AFTER 1500 --set SESSION_CONFIG.SECURITY_EXPIRE_AFTER 1800 --set TETHYS_PORTAL_CONFIG.STATIC_ROOT /var/lib/tethys_persist/static --set TETHYS_PORTAL_CONFIG.TETHYS_WORKSPACES_ROOT /var/lib/tethys_persist/workspaces --set RESOURCE_QUOTA_HANDLERS "[]" --set ANALYTICS_CONFIG "{}" --set AUTHENTICATION_BACKENDS "[]" --set OAUTH_CONFIG "{}" --set CHANNEL_LAYERS.default.BACKEND channels_redis.core.RedisChannelLayer --set CHANNEL_LAYERS.default.CONFIG "{"hosts":[["redis",6379]]}\ --set CAPTCHA_CONFIG.RECAPTCHA_PRIVATE_KEY '' --set CAPTCHA_CONFIG.RECAPTCHA_PUBLIC_KEY ''
+docker_portal-web-1  |               " run
+docker_portal-web-1  |      Started: 20:42:13.900614
+docker_portal-web-1  |     Duration: 2724.905 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   123
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   2
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   usage: tethys [-h]
+docker_portal-web-1  |                                 {version,app_settings,db,docker,gen,install,uninstall,link,list,manage,scaffold,schedulers,services,settings,site,syncstores,test}
+docker_portal-web-1  |                                 ...
+docker_portal-web-1  |                   tethys: error: unrecognized arguments: CAPTCHA_CONFIG.RECAPTCHA_PRIVATE_KEY
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Generate_NGINX_Settings_TethysCore
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: /opt/conda/envs/tethys/bin/tethys gen nginx --client-max-body-size 100M --overwrite
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command "/opt/conda/envs/tethys/bin/tethys gen nginx --client-max-body-size 100M --overwrite" run
+docker_portal-web-1  |      Started: 20:42:16.626057
+docker_portal-web-1  |     Duration: 2595.225 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   136
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  |                   ?[34mFile generated at "/usr/lib/tethys/tethys_nginx.conf".?[0m
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Generate_NGINX_Service_TethysCore
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: /opt/conda/envs/tethys/bin/tethys gen nginx_service --overwrite
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command "/opt/conda/envs/tethys/bin/tethys gen nginx_service --overwrite" run
+docker_portal-web-1  |      Started: 20:42:19.221669
+docker_portal-web-1  |     Duration: 2685.162 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   155
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  |                   ?[34mFile generated at "/usr/lib/tethys/nginx_supervisord.conf".?[0m
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Generate_ASGI_Service_TethysCore
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: /opt/conda/envs/tethys/bin/tethys gen asgi_service --asgi-processes 1 --conda-prefix /opt/conda/envs/tethys --overwrite
+docker_portal-web-1  | 
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command "/opt/conda/envs/tethys/bin/tethys gen asgi_service --asgi-processes 1 --conda-prefix /opt/conda/envs/tethys --overwrite
+docker_portal-web-1  |               " run
+docker_portal-web-1  |      Started: 20:42:21.907343
+docker_portal-web-1  |     Duration: 2999.692 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   168
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  |                   ?[34mFile generated at "/usr/lib/tethys/asgi_supervisord.conf".?[0m
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: /run/asgi
+docker_portal-web-1  |     Function: file.directory
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Directory /run/asgi updated
+docker_portal-web-1  |      Started: 20:42:24.907503
+docker_portal-web-1  |     Duration: 4.278 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               /run/asgi:
+docker_portal-web-1  |                   New Dir
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: /var/log/tethys/tethys.log
+docker_portal-web-1  |     Function: file.managed
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: File /var/log/tethys/tethys.log exists with proper permissions. No changes made.
+docker_portal-web-1  |      Started: 20:42:24.912134
+docker_portal-web-1  |     Duration: 2.496 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Create_Database_User_and_SuperUser_TethysCore
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: . /opt/conda/bin/activate tethys && PGPASSWORD="pass" /opt/conda/envs/tethys/bin/tethys db create -n tethys_default -p pass -N tethys_super -P pass
+docker_portal-web-1  | 
+docker_portal-web-1  |       Result: False
+docker_portal-web-1  |      Comment: Command ". /opt/conda/bin/activate tethys && PGPASSWORD="pass" /opt/conda/envs/tethys/bin/tethys db create -n tethys_default -p pass -N tethys_super -P pass
+docker_portal-web-1  |               " run
+docker_portal-web-1  |      Started: 20:42:24.914915
+docker_portal-web-1  |     Duration: 3002.595 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   182
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   2
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   psql: error: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  |                   ?[34mCreating Tethys database user "tethys_super"...?[0m
+docker_portal-web-1  |                   ?[31mFailed to create Tethys database user for "tethys_super"?[0m
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Migrate_Database_TethysCore
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: . /opt/conda/bin/activate tethys && /opt/conda/envs/tethys/bin/tethys db migrate
+docker_portal-web-1  | 
+docker_portal-web-1  |       Result: False
+docker_portal-web-1  |      Comment: Command ". /opt/conda/bin/activate tethys && /opt/conda/envs/tethys/bin/tethys db migrate
+docker_portal-web-1  |               " run
+docker_portal-web-1  |      Started: 20:42:27.917943
+docker_portal-web-1  |     Duration: 8842.001 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   201
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   1
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   The above exception was the direct cause of the following exception:
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_portal/manage.py", line 20, in <module>
+docker_portal-web-1  |                       execute_from_command_line(sys.argv)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
+docker_portal-web-1  |                       utility.execute()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 357, in execute
+docker_portal-web-1  |                       django.setup()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |                       apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |                       app_config.ready()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |                       self.module.autodiscover()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |                       autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |                       import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |                       return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |                       from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |                       register_custom_group()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |                       class CustomGroup(GroupAdmin):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |                       form = make_gop_app_access_form()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |                       for app_qs in all_apps:
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |                       self._fetch_all()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |                       self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |                       results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |                       cursor = self.connection.cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |                       return self._cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |                       self.ensure_connection()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |                       raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  |                   ?[34mRunning migrations for Tethys database...?[0m
+docker_portal-web-1  |                   ?[31mERROR!!!?[0m
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Create_Database_Portal_SuperUser_TethysCore
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: . /opt/conda/bin/activate tethys && /opt/conda/envs/tethys/bin/tethys db createsuperuser --pn admin --pp pass --pe gio.busrom@gmail.com
+docker_portal-web-1  | 
+docker_portal-web-1  |       Result: False
+docker_portal-web-1  |      Comment: Command ". /opt/conda/bin/activate tethys && /opt/conda/envs/tethys/bin/tethys db createsuperuser --pn admin --pp pass --pe gio.busrom@gmail.com
+docker_portal-web-1  |               " run
+docker_portal-web-1  |      Started: 20:42:36.760451
+docker_portal-web-1  |     Duration: 3711.515 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   229
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   1
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   The above exception was the direct cause of the following exception:
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |                       sys.exit(tethys_command())
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |                       args.func(args)
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/db_commands.py", line 385, in db_command
+docker_portal-web-1  |                       DB_COMMANDS[args.command](**options)
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/db_commands.py", line 295, in create_portal_superuser
+docker_portal-web-1  |                       load_apps()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |                       django.setup()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |                       apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |                       app_config.ready()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |                       self.module.autodiscover()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |                       autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |                       import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |                       return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |                       from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |                       register_custom_group()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |                       class CustomGroup(GroupAdmin):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |                       form = make_gop_app_access_form()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |                       for app_qs in all_apps:
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |                       self._fetch_all()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |                       self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |                       results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |                       cursor = self.connection.cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |                       return self._cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |                       self.ensure_connection()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |                       raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  |                   ?[34mCreating Tethys Portal superuser "admin"...?[0m
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Flag_Complete_Setup_TethysCore
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: touch /var/lib/tethys_persist/setup_complete
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command "touch /var/lib/tethys_persist/setup_complete" run
+docker_portal-web-1  |      Started: 20:42:40.472407
+docker_portal-web-1  |     Duration: 11.034 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   246
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Create_THREDDS_Spatial_Dataset_Service
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: . /opt/conda/bin/activate tethys && tethys services create spatial -t THREDDS -n tethys_thredds -c admin:pass@http://localhost:8080
+docker_portal-web-1  |       Result: False
+docker_portal-web-1  |      Comment: Command ". /opt/conda/bin/activate tethys && tethys services create spatial -t THREDDS -n tethys_thredds -c admin:pass@http://localhost:8080" run
+docker_portal-web-1  |      Started: 20:42:40.483777
+docker_portal-web-1  |     Duration: 2524.84 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   248
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   1
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   The above exception was the direct cause of the following exception:
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |                       sys.exit(tethys_command())
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |                       args.func(args)
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/services_commands.py", line 170, in services_create_spatial_command
+docker_portal-web-1  |                       load_apps()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |                       django.setup()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |                       apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |                       app_config.ready()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |                       self.module.autodiscover()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |                       autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |                       import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |                       return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |                       from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |                       register_custom_group()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |                       class CustomGroup(GroupAdmin):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |                       form = make_gop_app_access_form()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |                       for app_qs in all_apps:
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |                       self._fetch_all()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |                       self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |                       results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |                       cursor = self.connection.cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |                       return self._cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |                       self.ensure_connection()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |                       raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Create_GEOSERVER_Spatial_Dataset_Service
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: . /opt/conda/bin/activate tethys && tethys services create spatial -t GeoServer -n tethys_geoserver -c admin:geoserver@http://localhost:8081
+docker_portal-web-1  |       Result: False
+docker_portal-web-1  |      Comment: Command ". /opt/conda/bin/activate tethys && tethys services create spatial -t GeoServer -n tethys_geoserver -c admin:geoserver@http://localhost:8081" run
+docker_portal-web-1  |      Started: 20:42:43.009287
+docker_portal-web-1  |     Duration: 2535.313 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   266
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   1
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   The above exception was the direct cause of the following exception:
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |                       sys.exit(tethys_command())
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |                       args.func(args)
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/services_commands.py", line 170, in services_create_spatial_command
+docker_portal-web-1  |                       load_apps()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |                       django.setup()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |                       apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |                       app_config.ready()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |                       self.module.autodiscover()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |                       autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |                       import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |                       return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |                       from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |                       register_custom_group()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |                       class CustomGroup(GroupAdmin):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |                       form = make_gop_app_access_form()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |                       for app_qs in all_apps:
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |                       self._fetch_all()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |                       self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |                       results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |                       cursor = self.connection.cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |                       return self._cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |                       self.ensure_connection()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |                       raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Create_Persistent_Stores_Database
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: . /opt/conda/bin/activate tethys && tethys services create persistent -n tethys_postgres -c tethys_super:pass@db:5432
+docker_portal-web-1  |       Result: False
+docker_portal-web-1  |      Comment: Command ". /opt/conda/bin/activate tethys && tethys services create persistent -n tethys_postgres -c tethys_super:pass@db:5432" run
+docker_portal-web-1  |      Started: 20:42:45.545058
+docker_portal-web-1  |     Duration: 2574.739 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   284
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   1
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   The above exception was the direct cause of the following exception:
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |                       sys.exit(tethys_command())
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |                       args.func(args)
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/services_commands.py", line 134, in services_create_persistent_command
+docker_portal-web-1  |                       load_apps()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |                       django.setup()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |                       apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |                       app_config.ready()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |                       self.module.autodiscover()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |                       autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |                       import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |                       return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |                       from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |                       register_custom_group()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |                       class CustomGroup(GroupAdmin):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |                       form = make_gop_app_access_form()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |                       for app_qs in all_apps:
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |                       self._fetch_all()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |                       self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |                       results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |                       cursor = self.connection.cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |                       return self._cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |                       self.ensure_connection()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |                       raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Flag_Tethys_Services_Setup_Complete
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: touch /var/lib/tethys_persist/tethys_services_complete
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command "touch /var/lib/tethys_persist/tethys_services_complete" run
+docker_portal-web-1  |      Started: 20:42:48.120184
+docker_portal-web-1  |     Duration: 35.842 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   302
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Sync_Apps
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: . /opt/conda/bin/activate tethys && tethys db sync
+docker_portal-web-1  | 
+docker_portal-web-1  |       Result: False
+docker_portal-web-1  |      Comment: Command ". /opt/conda/bin/activate tethys && tethys db sync
+docker_portal-web-1  |               " run
+docker_portal-web-1  |      Started: 20:42:48.156545
+docker_portal-web-1  |     Duration: 2655.196 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   304
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   1
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   The above exception was the direct cause of the following exception:
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |                       sys.exit(tethys_command())
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |                       args.func(args)
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/db_commands.py", line 385, in db_command
+docker_portal-web-1  |                       DB_COMMANDS[args.command](**options)
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/db_commands.py", line 278, in sync_tethys_apps_db
+docker_portal-web-1  |                       load_apps()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |                       django.setup()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |                       apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |                       app_config.ready()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |                       self.module.autodiscover()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |                       autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |                       import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |                       return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |                       from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |                       register_custom_group()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |                       class CustomGroup(GroupAdmin):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |                       form = make_gop_app_access_form()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |                       for app_qs in all_apps:
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |                       self._fetch_all()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |                       self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |                       results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |                       cursor = self.connection.cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |                       return self._cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |                       self.ensure_connection()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |                       raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  |                   ?[34mSyncing the Tethys database with installed apps and extensions...?[0m
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Set_Custom_Settings
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: . /opt/conda/bin/activate tethys && tethys app_settings set Views Names Demonstration && tethys app_settings set endpoint https://indhri-hydro-apps.westus2.cloudapp.azure.com/geoserver && tethys app_settings set workspace hydroviewer tethys app_settings set Hydroser_Endpoint http://128.187.106.131/app/index.php/dr/services/cuahsi_1_1.asmx?WSDL
+docker_portal-web-1  | 
+docker_portal-web-1  |       Result: False
+docker_portal-web-1  |      Comment: Command ". /opt/conda/bin/activate tethys && tethys app_settings set Views Names Demonstration && tethys app_settings set endpoint https://indhri-hydro-apps.westus2.cloudapp.azure.com/geoserver && tethys app_settings set workspace hydroviewer tethys app_settings set Hydroser_Endpoint http://128.187.106.131/app/index.php/dr/services/cuahsi_1_1.asmx?WSDL
+docker_portal-web-1  |               " run
+docker_portal-web-1  |      Started: 20:42:50.812095
+docker_portal-web-1  |     Duration: 2567.778 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   329
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   1
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   The above exception was the direct cause of the following exception:
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |                       sys.exit(tethys_command())
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |                       args.func(args)
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/app_settings_commands.py", line 121, in app_settings_set_command
+docker_portal-web-1  |                       load_apps()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |                       django.setup()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |                       apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |                       app_config.ready()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |                       self.module.autodiscover()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |                       autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |                       import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |                       return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |                       from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |                       register_custom_group()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |                       class CustomGroup(GroupAdmin):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |                       form = make_gop_app_access_form()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |                       for app_qs in all_apps:
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |                       self._fetch_all()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |                       self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |                       results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |                       cursor = self.connection.cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |                       return self._cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |                       self.ensure_connection()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |                       raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Link_Tethys_Services_to_Apps
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: . /opt/conda/bin/activate tethys && tethys link persistent:tethys_postgres metdataexplorer2:ps_database:thredds_db && tethys link persistent:tethys_postgres water_data_explorer:ps_database:catalog_db &&        
+docker_portal-web-1  | 
+docker_portal-web-1  |       Result: False
+docker_portal-web-1  |      Comment: Command ". /opt/conda/bin/activate tethys && tethys link persistent:tethys_postgres metdataexplorer2:ps_database:thredds_db && tethys link persistent:tethys_postgres water_data_explorer:ps_database:catalog_db &&        
+docker_portal-web-1  |               " run
+docker_portal-web-1  |      Started: 20:42:53.380257
+docker_portal-web-1  |     Duration: 29.966 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   348
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   2
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   /bin/bash: -c: line 2: syntax error: unexpected end of file
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Sync_App_Persistent_Stores
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: . /opt/conda/bin/activate tethys && tethys syncstores all
+docker_portal-web-1  | 
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command ". /opt/conda/bin/activate tethys && tethys syncstores all
+docker_portal-web-1  |               " run
+docker_portal-web-1  |      Started: 20:42:53.410696
+docker_portal-web-1  |     Duration: 4058.486 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   350
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   The above exception was the direct cause of the following exception:
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_portal/manage.py", line 20, in <module>
+docker_portal-web-1  |                       execute_from_command_line(sys.argv)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
+docker_portal-web-1  |                       utility.execute()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 357, in execute
+docker_portal-web-1  |                       django.setup()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |                       apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |                       app_config.ready()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |                       self.module.autodiscover()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |                       autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |                       import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |                       return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |                       from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |                       register_custom_group()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |                       class CustomGroup(GroupAdmin):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |                       form = make_gop_app_access_form()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |                       for app_qs in all_apps:
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |                       self._fetch_all()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |                       self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |                       results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |                       cursor = self.connection.cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |                       return self._cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |                       self.ensure_connection()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |                       raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Flag_Init_Apps_Setup_Complete
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: touch /var/lib/tethys_persist/init_apps_setup_complete
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command "touch /var/lib/tethys_persist/init_apps_setup_complete" run
+docker_portal-web-1  |      Started: 20:42:57.469490
+docker_portal-web-1  |     Duration: 26.017 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   378
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Move_Custom_Theme_Files_to_Static_Root
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: mv /tmp/custom_theme /var/lib/tethys_persist/static
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command "mv /tmp/custom_theme /var/lib/tethys_persist/static" run
+docker_portal-web-1  |      Started: 20:42:57.495860
+docker_portal-web-1  |     Duration: 34.151 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   380
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Apply_Custom_Theme
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: . /opt/conda/bin/activate tethys && tethys site --title "Demonstration" --tab-title "My Portfolio Portal" --library-title "Tools" --primary-color "#01200F" --secondary-color "#358600" --background-color "#ffffff" --logo "/custom_theme/images/leaf-logo.png" --favicon "/custom_theme/images/favicon.ico" --copyright "Copyright © 2021 Gio"
+docker_portal-web-1  | 
+docker_portal-web-1  |       Result: False
+docker_portal-web-1  |      Comment: Command ". /opt/conda/bin/activate tethys && tethys site --title "Demonstration" --tab-title "My Portfolio Portal" --library-title "Tools" --primary-color "#01200F" --secondary-color "#358600" --background-color "#ffffff" --logo "/custom_theme/images/leaf-logo.png" --favicon "/custom_theme/images/favicon.ico" --copyright "Copyright © 2021 Gio"
+docker_portal-web-1  |               " run
+docker_portal-web-1  |      Started: 20:42:57.530285
+docker_portal-web-1  |     Duration: 2508.498 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   382
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   1
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   The above exception was the direct cause of the following exception:
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/bin/tethys", line 10, in <module>
+docker_portal-web-1  |                       sys.exit(tethys_command())
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/__init__.py", line 66, in tethys_command
+docker_portal-web-1  |                       args.func(args)
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/site_commands.py", line 184, in gen_site_content
+docker_portal-web-1  |                       load_apps()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_cli/cli_helpers.py", line 55, in load_apps
+docker_portal-web-1  |                       django.setup()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |                       apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |                       app_config.ready()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |                       self.module.autodiscover()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |                       autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |                       import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |                       return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |                       from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |                       register_custom_group()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |                       class CustomGroup(GroupAdmin):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |                       form = make_gop_app_access_form()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |                       for app_qs in all_apps:
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |                       self._fetch_all()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |                       self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |                       results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |                       cursor = self.connection.cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |                       return self._cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |                       self.ensure_connection()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |                       raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Flag_Custom_Theme_Setup_Complete
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: touch /var/lib/tethys_persist/custom_theme_setup_complete
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command "touch /var/lib/tethys_persist/custom_theme_setup_complete" run
+docker_portal-web-1  |      Started: 20:43:00.039188
+docker_portal-web-1  |     Duration: 30.652 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   400
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Persist_Portal_Config_Post_App
+docker_portal-web-1  |     Function: file.rename
+docker_portal-web-1  |         Name: /var/lib/tethys_persist/portal_config.yml
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Moved "/usr/lib/tethys/portal_config.yml" to "/var/lib/tethys_persist/portal_config.yml"
+docker_portal-web-1  |      Started: 20:43:00.070084
+docker_portal-web-1  |     Duration: 17.266 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               /var/lib/tethys_persist/portal_config.yml:
+docker_portal-web-1  |                   /usr/lib/tethys/portal_config.yml
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Restore_Portal_Config_Post_App
+docker_portal-web-1  |     Function: file.symlink
+docker_portal-web-1  |         Name: /usr/lib/tethys/portal_config.yml
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Created new symlink /usr/lib/tethys/portal_config.yml -> /var/lib/tethys_persist/portal_config.yml
+docker_portal-web-1  |      Started: 20:43:00.087584
+docker_portal-web-1  |     Duration: 2.046 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               new:
+docker_portal-web-1  |                   /usr/lib/tethys/portal_config.yml
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Chown_Portal_Config_Post_App
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: chown www:www /usr/lib/tethys/portal_config.yml
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command "chown www:www /usr/lib/tethys/portal_config.yml" run
+docker_portal-web-1  |      Started: 20:43:00.089747
+docker_portal-web-1  |     Duration: 11.081 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   403
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Collect_Static
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: . /opt/conda/bin/activate tethys && cat /usr/lib/tethys/portal_config.yml && cat /usr/lib/tethys/tethys/tethys_portal/settings.py && tethys manage collectstatic --noinput
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command ". /opt/conda/bin/activate tethys && cat /usr/lib/tethys/portal_config.yml && cat /usr/lib/tethys/tethys/tethys_portal/settings.py && tethys manage collectstatic --noinput" run
+docker_portal-web-1  |      Started: 20:43:00.101175
+docker_portal-web-1  |     Duration: 6102.883 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   404
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   The above exception was the direct cause of the following exception:
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_portal/manage.py", line 20, in <module>
+docker_portal-web-1  |                       execute_from_command_line(sys.argv)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
+docker_portal-web-1  |                       utility.execute()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 357, in execute
+docker_portal-web-1  |                       django.setup()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |                       apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |                       app_config.ready()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |                       self.module.autodiscover()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |                       autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |                       import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |                       return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |                       from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |                       register_custom_group()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |                       class CustomGroup(GroupAdmin):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |                       form = make_gop_app_access_form()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |                       for app_qs in all_apps:
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |                       self._fetch_all()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |                       self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |                       results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |                       cursor = self.connection.cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |                       return self._cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |                       self.ensure_connection()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |                       raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   The above exception was the direct cause of the following exception:
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_portal/manage.py", line 20, in <module>
+docker_portal-web-1  |                       execute_from_command_line(sys.argv)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
+docker_portal-web-1  |                       utility.execute()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 357, in execute
+docker_portal-web-1  |                       django.setup()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |                       apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |                       app_config.ready()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |                       self.module.autodiscover()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |                       autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |                       import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |                       return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |                       from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |                       register_custom_group()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |                       class CustomGroup(GroupAdmin):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |                       form = make_gop_app_access_form()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |                       for app_qs in all_apps:
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |                       self._fetch_all()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |                       self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |                       results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |                       cursor = self.connection.cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |                       return self._cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |                       self.ensure_connection()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |                       raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  |                   # Portal Level Config File
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # see tethys documentation for how to setup this file
+docker_portal-web-1  |                   version: 1.0
+docker_portal-web-1  |                   name:
+docker_portal-web-1  |                   apps: {}
+docker_portal-web-1  |                   settings:
+docker_portal-web-1  |                     SECRET_KEY: 7EVYSxJF1CwuZ8k4NDKG1uoMIWCUThAhkKKCdvsE1yKpqDppO4
+docker_portal-web-1  |                   site_content: {}"""
+docker_portal-web-1  |                   Settings for Tethys Platform
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   ***************************************************************************
+docker_portal-web-1  |                   *
+docker_portal-web-1  |                   *   WARNING!!!!
+docker_portal-web-1  |                   *
+docker_portal-web-1  |                   *   The settings.py file should no longer be edited to customize your local
+docker_portal-web-1  |                   *   settings. All portal configuration should now happen in the portal_config.yml
+docker_portal-web-1  |                   *   file (See docs/tethys_portal/configuration.rst).
+docker_portal-web-1  |                   *
+docker_portal-web-1  |                   ***************************************************************************
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   This file contains default Django and other settings for the Tethys Platform.
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   For more information on this file, see
+docker_portal-web-1  |                   https://docs.djangoproject.com/en/1.9/topics/settings/
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   For the full list of settings and their values, see
+docker_portal-web-1  |                   https://docs.djangoproject.com/en/1.9/ref/settings/
+docker_portal-web-1  |                   """
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+docker_portal-web-1  |                   import os
+docker_portal-web-1  |                   import sys
+docker_portal-web-1  |                   import yaml
+docker_portal-web-1  |                   import logging
+docker_portal-web-1  |                   import datetime as dt
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   from django.contrib.messages import constants as message_constants
+docker_portal-web-1  |                   from tethys_apps.utilities import get_tethys_home_dir
+docker_portal-web-1  |                   from tethys_cli.gen_commands import generate_secret_key
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   from bokeh.settings import settings as bokeh_settings
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   log = logging.getLogger(__name__)
+docker_portal-web-1  |                   this_module = sys.modules[__name__]
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   BASE_DIR = os.path.dirname(__file__)
+docker_portal-web-1  |                   TETHYS_HOME = get_tethys_home_dir()
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   portal_config_settings = {}
+docker_portal-web-1  |                   try:
+docker_portal-web-1  |                       with open(os.path.join(TETHYS_HOME, 'portal_config.yml')) as portal_yaml:
+docker_portal-web-1  |                           portal_config_settings = yaml.safe_load(portal_yaml).get('settings', {}) or {}
+docker_portal-web-1  |                   except FileNotFoundError:
+docker_portal-web-1  |                       log.info('Could not find the portal_config.yml file. To generate a new portal_config.yml run the command '
+docker_portal-web-1  |                                '"tethys gen portal_config"')
+docker_portal-web-1  |                   except Exception:
+docker_portal-web-1  |                       log.exception('There was an error while attempting to read the settings from the portal_config.yml file.')
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   bokeh_settings.resources = portal_config_settings.pop('BOKEH_RESOURCES', 'cdn')
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Quick-start development settings - unsuitable for production
+docker_portal-web-1  |                   # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # SECURITY WARNING: keep the secret key used in production secret!
+docker_portal-web-1  |                   SECRET_KEY = portal_config_settings.pop('SECRET_KEY', generate_secret_key())
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # SECURITY WARNING: don't run with debug turned on in production!
+docker_portal-web-1  |                   DEBUG = portal_config_settings.pop('DEBUG', True)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   ALLOWED_HOSTS = portal_config_settings.pop('ALLOWED_HOSTS', [])
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # List those who should be notified of an error when DEBUG = False as a tuple of (name, email address).
+docker_portal-web-1  |                   # i.e.: ADMINS = (('John', 'john@example.com'), ('Mary', 'mary@example.com'))
+docker_portal-web-1  |                   ADMINS = portal_config_settings.pop('ADMINS', ())
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   TETHYS_PORTAL_CONFIG = portal_config_settings.pop('TETHYS_PORTAL_CONFIG', {})
+docker_portal-web-1  |                   # Use this setting to bypass the home page
+docker_portal-web-1  |                   BYPASS_TETHYS_HOME_PAGE = TETHYS_PORTAL_CONFIG.pop('BYPASS_TETHYS_HOME_PAGE', False)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Use this setting to disable open account signup
+docker_portal-web-1  |                   ENABLE_OPEN_SIGNUP = TETHYS_PORTAL_CONFIG.pop('ENABLE_OPEN_SIGNUP', False)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Set to True to allow Open Portal mode. This mode supersedes any specific user/group app access permissions
+docker_portal-web-1  |                   ENABLE_OPEN_PORTAL = TETHYS_PORTAL_CONFIG.pop('ENABLE_OPEN_PORTAL', False)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Set to True to allow Open Portal mode. This mode supersedes any specific user/group app access permissions
+docker_portal-web-1  |                   ENABLE_RESTRICTED_APP_ACCESS = TETHYS_PORTAL_CONFIG.pop('ENABLE_RESTRICTED_APP_ACCESS', False)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   SESSION_CONFIG = portal_config_settings.pop('SESSION_CONFIG', {})
+docker_portal-web-1  |                   # Force user logout once the browser has been closed.
+docker_portal-web-1  |                   # If changed, delete all django_session table entries from the tethys_default database to ensure updated behavior
+docker_portal-web-1  |                   SESSION_EXPIRE_AT_BROWSER_CLOSE = SESSION_CONFIG.pop('SESSION_EXPIRE_AT_BROWSER_CLOSE', True)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Warn user of forced logout after indicated number of seconds
+docker_portal-web-1  |                   SESSION_SECURITY_WARN_AFTER = SESSION_CONFIG.pop('SESSION_SECURITY_WARN_AFTER', 840)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Force user logout after a certain number of seconds
+docker_portal-web-1  |                   SESSION_SECURITY_EXPIRE_AFTER = SESSION_CONFIG.pop('SESSION_SECURITY_EXPIRE_AFTER', 900)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # add any additional SESSION_CONFIG settings
+docker_portal-web-1  |                   for setting, value in SESSION_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   DATABASES = portal_config_settings.pop('DATABASES', {})
+docker_portal-web-1  |                   DATABASES.setdefault('default', {'DIR': 'psql'})
+docker_portal-web-1  |                   DEFAULT_DB = DATABASES['default']
+docker_portal-web-1  |                   DEFAULT_DB.setdefault('ENGINE', 'django.db.backends.postgresql_psycopg2')
+docker_portal-web-1  |                   DEFAULT_DB.setdefault('NAME', 'tethys_platform')
+docker_portal-web-1  |                   DEFAULT_DB.setdefault('USER', 'tethys_default')
+docker_portal-web-1  |                   DEFAULT_DB.setdefault('PASSWORD', 'pass')
+docker_portal-web-1  |                   DEFAULT_DB.setdefault('HOST', 'localhost')
+docker_portal-web-1  |                   DEFAULT_DB.setdefault('PORT', 5436)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   LOGGING_CONFIG = portal_config_settings.pop('LOGGING_CONFIG', {})
+docker_portal-web-1  |                   # See https://docs.djangoproject.com/en/1.8/topics/logging/#configuring-logging for more logging configuration options.
+docker_portal-web-1  |                   LOGGING = portal_config_settings.pop('LOGGING', {})
+docker_portal-web-1  |                   LOGGING.setdefault('version', 1)
+docker_portal-web-1  |                   LOGGING.setdefault('disable_existing_loggers', False)
+docker_portal-web-1  |                   LOGGING.setdefault('formatters', {
+docker_portal-web-1  |                       'verbose': {
+docker_portal-web-1  |                           'format': '%(levelname)s:%(name)s:%(message)s'
+docker_portal-web-1  |                       },
+docker_portal-web-1  |                       'simple': {
+docker_portal-web-1  |                           'format': '%(levelname)s %(message)s'
+docker_portal-web-1  |                       },
+docker_portal-web-1  |                   })
+docker_portal-web-1  |                   LOGGING.setdefault('handlers', {
+docker_portal-web-1  |                       'console_simple': {
+docker_portal-web-1  |                           'class': 'logging.StreamHandler',
+docker_portal-web-1  |                           'formatter': 'simple'
+docker_portal-web-1  |                       },
+docker_portal-web-1  |                       'console_verbose': {
+docker_portal-web-1  |                           'class': 'logging.StreamHandler',
+docker_portal-web-1  |                           'formatter': 'verbose'
+docker_portal-web-1  |                       },
+docker_portal-web-1  |                   })
+docker_portal-web-1  |                   LOGGING.setdefault('loggers', {})
+docker_portal-web-1  |                   LOGGERS = LOGGING['loggers']
+docker_portal-web-1  |                   LOGGERS.setdefault('django', {
+docker_portal-web-1  |                       'handlers': ['console_simple'],
+docker_portal-web-1  |                       'level': os.getenv('DJANGO_LOG_LEVEL', 'WARNING'),
+docker_portal-web-1  |                   })
+docker_portal-web-1  |                   LOGGERS.setdefault('tethys', {
+docker_portal-web-1  |                       'handlers': ['console_verbose'],
+docker_portal-web-1  |                       'level': 'INFO',
+docker_portal-web-1  |                   })
+docker_portal-web-1  |                   LOGGERS.setdefault('tethys.apps', {
+docker_portal-web-1  |                       'handlers': ['console_verbose'],
+docker_portal-web-1  |                       'level': 'INFO',
+docker_portal-web-1  |                   })
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   INSTALLED_APPS = portal_config_settings.pop('INSTALLED_APPS_OVERRIDE', [
+docker_portal-web-1  |                       'django.contrib.admin',
+docker_portal-web-1  |                       'django.contrib.auth',
+docker_portal-web-1  |                       'django.contrib.contenttypes',
+docker_portal-web-1  |                       'django.contrib.sessions',
+docker_portal-web-1  |                       'django.contrib.messages',
+docker_portal-web-1  |                       'django.contrib.staticfiles',
+docker_portal-web-1  |                       'django_gravatar',
+docker_portal-web-1  |                       'bootstrap3',
+docker_portal-web-1  |                       'termsandconditions',
+docker_portal-web-1  |                       'tethys_config',
+docker_portal-web-1  |                       'tethys_apps',
+docker_portal-web-1  |                       'tethys_gizmos',
+docker_portal-web-1  |                       'tethys_services',
+docker_portal-web-1  |                       'tethys_compute',
+docker_portal-web-1  |                       'tethys_quotas',
+docker_portal-web-1  |                       'social_django',
+docker_portal-web-1  |                       'guardian',
+docker_portal-web-1  |                       'session_security',
+docker_portal-web-1  |                       'captcha',
+docker_portal-web-1  |                       'snowpenguin.django.recaptcha2',
+docker_portal-web-1  |                       'rest_framework',
+docker_portal-web-1  |                       'rest_framework.authtoken',
+docker_portal-web-1  |                       'analytical',
+docker_portal-web-1  |                       'channels',
+docker_portal-web-1  |                       'mfa',
+docker_portal-web-1  |                       'axes',
+docker_portal-web-1  |                   ])
+docker_portal-web-1  |                   INSTALLED_APPS = tuple(INSTALLED_APPS + portal_config_settings.pop('INSTALLED_APPS', []))
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   MIDDLEWARE = portal_config_settings.pop('MIDDLEWARE_OVERRIDE', [
+docker_portal-web-1  |                       'django.contrib.sessions.middleware.SessionMiddleware',
+docker_portal-web-1  |                       'django.middleware.common.CommonMiddleware',
+docker_portal-web-1  |                       'django.middleware.csrf.CsrfViewMiddleware',
+docker_portal-web-1  |                       'django.contrib.auth.middleware.AuthenticationMiddleware',
+docker_portal-web-1  |                       'django.contrib.messages.middleware.MessageMiddleware',
+docker_portal-web-1  |                       'tethys_portal.middleware.TethysMfaRequiredMiddleware',
+docker_portal-web-1  |                       'django.middleware.clickjacking.XFrameOptionsMiddleware',
+docker_portal-web-1  |                       'tethys_portal.middleware.TethysSocialAuthExceptionMiddleware',
+docker_portal-web-1  |                       'tethys_portal.middleware.TethysAppAccessMiddleware',
+docker_portal-web-1  |                       'session_security.middleware.SessionSecurityMiddleware',
+docker_portal-web-1  |                       'axes.middleware.AxesMiddleware',
+docker_portal-web-1  |                   ])
+docker_portal-web-1  |                   MIDDLEWARE = tuple(MIDDLEWARE + portal_config_settings.pop('MIDDLEWARE', []))
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   AUTHENTICATION_BACKENDS = portal_config_settings.pop('AUTHENTICATION_BACKENDS_OVERRIDE', [
+docker_portal-web-1  |                       'axes.backends.AxesBackend',
+docker_portal-web-1  |                       'django.contrib.auth.backends.ModelBackend',
+docker_portal-web-1  |                       'guardian.backends.ObjectPermissionBackend',
+docker_portal-web-1  |                   ])
+docker_portal-web-1  |                   AUTHENTICATION_BACKENDS = tuple(portal_config_settings.pop('AUTHENTICATION_BACKENDS', []) + AUTHENTICATION_BACKENDS)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   RESOURCE_QUOTA_HANDLERS = portal_config_settings.pop('RESOURCE_QUOTA_HANDLERS_OVERRIDE', [
+docker_portal-web-1  |                       "tethys_quotas.handlers.workspace.WorkspaceQuotaHandler",
+docker_portal-web-1  |                   ])
+docker_portal-web-1  |                   RESOURCE_QUOTA_HANDLERS = tuple(RESOURCE_QUOTA_HANDLERS + portal_config_settings.pop('RESOURCE_QUOTA_HANDLERS', []))
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   REST_FRAMEWORK = {
+docker_portal-web-1  |                       'DEFAULT_PERMISSION_CLASSES': (
+docker_portal-web-1  |                           'rest_framework.permissions.IsAuthenticated',
+docker_portal-web-1  |                       ),
+docker_portal-web-1  |                       'DEFAULT_AUTHENTICATION_CLASSES': (
+docker_portal-web-1  |                           'rest_framework.authentication.TokenAuthentication',
+docker_portal-web-1  |                       )
+docker_portal-web-1  |                   }
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Terms and conditions settings
+docker_portal-web-1  |                   ACCEPT_TERMS_PATH = '/terms/accept/'
+docker_portal-web-1  |                   TERMS_EXCLUDE_URL_PREFIX_LIST = {'/admin/', '/oauth2/', '/handoff/', '/accounts/', '/terms/'}
+docker_portal-web-1  |                   TERMS_EXCLUDE_URL_LIST = {'/'}
+docker_portal-web-1  |                   TERMS_BASE_TEMPLATE = 'page.html'
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   ROOT_URLCONF = 'tethys_portal.urls'
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Internationalization
+docker_portal-web-1  |                   # https://docs.djangoproject.com/en/1.9/topics/i18n/
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   LANGUAGE_CODE = 'en-us'
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   TIME_ZONE = 'UTC'
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   USE_I18N = True
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   USE_L10N = True
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   USE_TZ = True
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Templates
+docker_portal-web-1  |                   TEMPLATES = [
+docker_portal-web-1  |                       {
+docker_portal-web-1  |                           'BACKEND': 'django.template.backends.django.DjangoTemplates',
+docker_portal-web-1  |                           'DIRS': [
+docker_portal-web-1  |                               os.path.join(BASE_DIR, 'templates'),
+docker_portal-web-1  |                           ],
+docker_portal-web-1  |                           'OPTIONS': {
+docker_portal-web-1  |                               'context_processors': [
+docker_portal-web-1  |                                   'django.contrib.auth.context_processors.auth',
+docker_portal-web-1  |                                   'django.template.context_processors.debug',
+docker_portal-web-1  |                                   'django.template.context_processors.i18n',
+docker_portal-web-1  |                                   'django.template.context_processors.media',
+docker_portal-web-1  |                                   'django.template.context_processors.static',
+docker_portal-web-1  |                                   'django.template.context_processors.tz',
+docker_portal-web-1  |                                   'django.template.context_processors.request',
+docker_portal-web-1  |                                   'django.contrib.messages.context_processors.messages',
+docker_portal-web-1  |                                   'social_django.context_processors.backends',
+docker_portal-web-1  |                                   'social_django.context_processors.login_redirect',
+docker_portal-web-1  |                                   'tethys_config.context_processors.tethys_global_settings_context',
+docker_portal-web-1  |                                   'tethys_apps.context_processors.tethys_apps_context',
+docker_portal-web-1  |                                   'tethys_gizmos.context_processors.tethys_gizmos_context'
+docker_portal-web-1  |                               ],
+docker_portal-web-1  |                               'loaders': [
+docker_portal-web-1  |                                   'django.template.loaders.filesystem.Loader',
+docker_portal-web-1  |                                   'django.template.loaders.app_directories.Loader',
+docker_portal-web-1  |                                   'tethys_apps.template_loaders.TethysTemplateLoader'
+docker_portal-web-1  |                               ],
+docker_portal-web-1  |                               'debug': DEBUG
+docker_portal-web-1  |                           }
+docker_portal-web-1  |                       }
+docker_portal-web-1  |                   ]
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Static files (CSS, JavaScript, Images)
+docker_portal-web-1  |                   # https://docs.djangoproject.com/en/1.9/howto/static-files/
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   STATIC_URL = '/static/'
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   STATICFILES_DIRS = (os.path.join(BASE_DIR, 'static'),)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   STATICFILES_FINDERS = (
+docker_portal-web-1  |                       'django.contrib.staticfiles.finders.FileSystemFinder',
+docker_portal-web-1  |                       'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+docker_portal-web-1  |                       'tethys_apps.static_finders.TethysStaticFinder'
+docker_portal-web-1  |                   )
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   STATIC_ROOT = TETHYS_PORTAL_CONFIG.pop('STATIC_ROOT', os.path.join(TETHYS_HOME, 'static'))
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   TETHYS_WORKSPACES_ROOT = TETHYS_PORTAL_CONFIG.pop('TETHYS_WORKSPACES_ROOT', os.path.join(TETHYS_HOME, 'workspaces'))
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # add any additional TETHYS_PORTAL_CONFIG settings
+docker_portal-web-1  |                   for setting, value in TETHYS_PORTAL_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Messaging settings
+docker_portal-web-1  |                   MESSAGE_TAGS = {
+docker_portal-web-1  |                       message_constants.DEBUG: 'alert-danger',
+docker_portal-web-1  |                       message_constants.INFO: 'alert-info',
+docker_portal-web-1  |                       message_constants.SUCCESS: 'alert-success',
+docker_portal-web-1  |                       message_constants.WARNING: 'alert-warning',
+docker_portal-web-1  |                       message_constants.ERROR: 'alert-danger'
+docker_portal-web-1  |                   }
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Email Configuration
+docker_portal-web-1  |                   EMAIL_CONFIG = portal_config_settings.pop('EMAIL_CONFIG', {})
+docker_portal-web-1  |                   EMAIL_FROM = portal_config_settings.pop('EMAIL_FROM', '')
+docker_portal-web-1  |                   for setting, value in EMAIL_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Gravatar Settings
+docker_portal-web-1  |                   GRAVATAR_URL = 'http://www.gravatar.com/'
+docker_portal-web-1  |                   GRAVATAR_SECURE_URL = 'https://secure.gravatar.com/'
+docker_portal-web-1  |                   GRAVATAR_DEFAULT_SIZE = '80'
+docker_portal-web-1  |                   GRAVATAR_DEFAULT_IMAGE = 'retro'
+docker_portal-web-1  |                   GRAVATAR_DEFAULT_RATING = 'g'
+docker_portal-web-1  |                   GRAVATAR_DFFAULT_SECURE = True
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # OAuth Settings
+docker_portal-web-1  |                   # http://psa.matiasaguirre.net/docs/configuration/index.html
+docker_portal-web-1  |                   SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['username', 'first_name', 'email']
+docker_portal-web-1  |                   SOCIAL_AUTH_SLUGIFY_USERNAMES = True
+docker_portal-web-1  |                   SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/apps/'
+docker_portal-web-1  |                   SOCIAL_AUTH_LOGIN_ERROR_URL = '/accounts/login/'
+docker_portal-web-1  |                   SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = ['tenant']
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # OAuth Providers
+docker_portal-web-1  |                   OAUTH_CONFIG = portal_config_settings.pop('OAUTH_CONFIG', {})
+docker_portal-web-1  |                   for setting, value in OAUTH_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # MFA Settings
+docker_portal-web-1  |                   # See: https://github.com/mkalioby/django-mfa2
+docker_portal-web-1  |                   # Methods that shouldn't be allowed for the user, U2F, FIDO2, TOTP, Trusted_Devices, Email
+docker_portal-web-1  |                   MFA_REQUIRED = False                # Require all users to set up MFA
+docker_portal-web-1  |                   SSO_MFA_REQUIRED = False            # Require users logged in with SSO to set up MFA when MFA_REQUIRED is True
+docker_portal-web-1  |                   ADMIN_MFA_REQUIRED = True           # Require admin users to set up MFA when MFA_REQUIRED is True
+docker_portal-web-1  |                   MFA_UNALLOWED_METHODS = ('U2F', 'FIDO2', 'Email', 'Trusted_Devices')
+docker_portal-web-1  |                   # A function that should be called by username to login the user in session
+docker_portal-web-1  |                   MFA_LOGIN_CALLBACK = 'tethys_portal.utilities.log_user_in'
+docker_portal-web-1  |                   MFA_RECHECK = False                  # Allow random rechecking of the user
+docker_portal-web-1  |                   MFA_RECHECK_MIN = 600                # Minimum interval in seconds
+docker_portal-web-1  |                   MFA_RECHECK_MAX = 1800               # Maximum in seconds
+docker_portal-web-1  |                   MFA_QUICKLOGIN = False               # Allow quick login for returning users by provide only their 2FA
+docker_portal-web-1  |                   MFA_HIDE_DISABLE = ('FIDO2',)        # Can the user disable his key (Added in 1.2.0).
+docker_portal-web-1  |                   MFA_OWNED_BY_ENTERPRISE = False      # Who owns security keys
+docker_portal-web-1  |                   TOKEN_ISSUER_NAME = 'Tethys Portal'  # TOTP Issuer name
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   U2F_APPID = 'http://localhost'       # URL For U2F
+docker_portal-web-1  |                   FIDO_SERVER_ID = u'localhost'        # Server rp id for FIDO2, it's the full domain of your project
+docker_portal-web-1  |                   FIDO_SERVER_NAME = u'Tethys Portal'
+docker_portal-web-1  |                   FIDO_LOGIN_URL = '/auth/login'
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   MFA_CONFIG = portal_config_settings.pop('MFA_CONFIG', {})
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   for setting, value in MFA_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Lockout Configuration
+docker_portal-web-1  |                   AXES_ENABLED = not DEBUG
+docker_portal-web-1  |                   AXES_FAILURE_LIMIT = 3
+docker_portal-web-1  |                   AXES_COOLOFF_TIME = dt.timedelta(hours=0.5)
+docker_portal-web-1  |                   AXES_ONLY_USER_FAILURES = True
+docker_portal-web-1  |                   AXES_ENABLE_ADMIN = True
+docker_portal-web-1  |                   AXES_LOCKOUT_TEMPLATE = 'tethys_portal/accounts/lockout.html'
+docker_portal-web-1  |                   AXES_VERBOSE = True
+docker_portal-web-1  |                   AXES_RESET_ON_SUCCESS = True
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   LOCKOUT_CONFIG = portal_config_settings.pop('LOCKOUT_CONFIG', {})
+docker_portal-web-1  |                   for setting, value in LOCKOUT_CONFIG.items():
+docker_portal-web-1  |                       if setting == 'AXES_COOLOFF_TIME' and isinstance(value, str):
+docker_portal-web-1  |                           import isodate
+docker_portal-web-1  |                           try:
+docker_portal-web-1  |                               value = isodate.parse_duration(value)
+docker_portal-web-1  |                           except Exception:
+docker_portal-web-1  |                               pass
+docker_portal-web-1  |                   
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Django Guardian Settings
+docker_portal-web-1  |                   ANONYMOUS_USER_ID = -1
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   CAPTCHA_CONFIG = portal_config_settings.pop('CAPTCHA_CONFIG', {})
+docker_portal-web-1  |                   for setting, value in CAPTCHA_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   # If you require reCaptcha to be loaded from somewhere other than https://google.com
+docker_portal-web-1  |                   # (e.g. to bypass firewall restrictions), you can specify what proxy to use.
+docker_portal-web-1  |                   # RECAPTCHA_PROXY_HOST: https://recaptcha.net
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Placeholders for the ID's required by various web-analytics services supported by Django-Analytical.
+docker_portal-web-1  |                   # Replace False with the tracking ID as a string e.g. SERVICE_ID = 'abcd1234'
+docker_portal-web-1  |                   ANALYTICS_CONFIG = portal_config_settings.pop('ANALYTICS_CONFIG', {})
+docker_portal-web-1  |                   for setting, value in ANALYTICS_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   ASGI_APPLICATION = "tethys_portal.routing.application"
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Add any additional specified settings to module
+docker_portal-web-1  |                   for setting, value in portal_config_settings.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Collect_Workspaces
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: . /opt/conda/bin/activate tethys && cat /usr/lib/tethys/portal_config.yml && cat /usr/lib/tethys/tethys/tethys_portal/settings.py && tethys manage collectworkspaces
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command ". /opt/conda/bin/activate tethys && cat /usr/lib/tethys/portal_config.yml && cat /usr/lib/tethys/tethys/tethys_portal/settings.py && tethys manage collectworkspaces" run
+docker_portal-web-1  |      Started: 20:43:06.204313
+docker_portal-web-1  |     Duration: 3723.757 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   443
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   psycopg2.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   The above exception was the direct cause of the following exception:
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   Traceback (most recent call last):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_portal/manage.py", line 20, in <module>
+docker_portal-web-1  |                       execute_from_command_line(sys.argv)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
+docker_portal-web-1  |                       utility.execute()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/core/management/__init__.py", line 357, in execute
+docker_portal-web-1  |                       django.setup()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
+docker_portal-web-1  |                       apps.populate(settings.INSTALLED_APPS)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
+docker_portal-web-1  |                       app_config.ready()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/apps.py", line 24, in ready
+docker_portal-web-1  |                       self.module.autodiscover()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
+docker_portal-web-1  |                       autodiscover_modules('admin', register_to=site)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/utils/module_loading.py", line 47, in autodiscover_modules
+docker_portal-web-1  |                       import_module('%s.%s' % (app_config.name, module_to_search))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/importlib/__init__.py", line 127, in import_module
+docker_portal-web-1  |                       return _bootstrap._gcd_import(name[level:], package, level)
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 983, in _find_and_load
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap_external>", line 728, in exec_module
+docker_portal-web-1  |                     File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_config/admin.py", line 14, in <module>
+docker_portal-web-1  |                       from tethys_apps.admin import TethysAppSettingInline
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 343, in <module>
+docker_portal-web-1  |                       register_custom_group()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 325, in register_custom_group
+docker_portal-web-1  |                       class CustomGroup(GroupAdmin):
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 326, in CustomGroup
+docker_portal-web-1  |                       form = make_gop_app_access_form()
+docker_portal-web-1  |                     File "/usr/lib/tethys/tethys/tethys_apps/admin.py", line 278, in make_gop_app_access_form
+docker_portal-web-1  |                       for app_qs in all_apps:
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 274, in __iter__
+docker_portal-web-1  |                       self._fetch_all()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
+docker_portal-web-1  |                       self._result_cache = list(self._iterable_class(self))
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
+docker_portal-web-1  |                       results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1138, in execute_sql
+docker_portal-web-1  |                       cursor = self.connection.cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 256, in cursor
+docker_portal-web-1  |                       return self._cursor()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 233, in _cursor
+docker_portal-web-1  |                       self.ensure_connection()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/utils.py", line 89, in __exit__
+docker_portal-web-1  |                       raise dj_exc_value.with_traceback(traceback) from exc_value
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
+docker_portal-web-1  |                       self.connect()
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/base/base.py", line 195, in connect
+docker_portal-web-1  |                       self.connection = self.get_new_connection(conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
+docker_portal-web-1  |                       connection = Database.connect(**conn_params)
+docker_portal-web-1  |                     File "/opt/conda/envs/tethys/lib/python3.7/site-packages/psycopg2/__init__.py", line 122, in connect
+docker_portal-web-1  |                       conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+docker_portal-web-1  |                   django.db.utils.OperationalError: could not connect to server: Connection refused
+docker_portal-web-1  |                   	Is the server running on host "localhost" (127.0.0.1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |                   could not connect to server: Cannot assign requested address
+docker_portal-web-1  |                   	Is the server running on host "localhost" (::1) and accepting
+docker_portal-web-1  |                   	TCP/IP connections on port 5436?
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  |                   # Portal Level Config File
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # see tethys documentation for how to setup this file
+docker_portal-web-1  |                   version: 1.0
+docker_portal-web-1  |                   name:
+docker_portal-web-1  |                   apps: {}
+docker_portal-web-1  |                   settings:
+docker_portal-web-1  |                     SECRET_KEY: 7EVYSxJF1CwuZ8k4NDKG1uoMIWCUThAhkKKCdvsE1yKpqDppO4
+docker_portal-web-1  |                   site_content: {}"""
+docker_portal-web-1  |                   Settings for Tethys Platform
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   ***************************************************************************
+docker_portal-web-1  |                   *
+docker_portal-web-1  |                   *   WARNING!!!!
+docker_portal-web-1  |                   *
+docker_portal-web-1  |                   *   The settings.py file should no longer be edited to customize your local
+docker_portal-web-1  |                   *   settings. All portal configuration should now happen in the portal_config.yml
+docker_portal-web-1  |                   *   file (See docs/tethys_portal/configuration.rst).
+docker_portal-web-1  |                   *
+docker_portal-web-1  |                   ***************************************************************************
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   This file contains default Django and other settings for the Tethys Platform.
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   For more information on this file, see
+docker_portal-web-1  |                   https://docs.djangoproject.com/en/1.9/topics/settings/
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   For the full list of settings and their values, see
+docker_portal-web-1  |                   https://docs.djangoproject.com/en/1.9/ref/settings/
+docker_portal-web-1  |                   """
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+docker_portal-web-1  |                   import os
+docker_portal-web-1  |                   import sys
+docker_portal-web-1  |                   import yaml
+docker_portal-web-1  |                   import logging
+docker_portal-web-1  |                   import datetime as dt
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   from django.contrib.messages import constants as message_constants
+docker_portal-web-1  |                   from tethys_apps.utilities import get_tethys_home_dir
+docker_portal-web-1  |                   from tethys_cli.gen_commands import generate_secret_key
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   from bokeh.settings import settings as bokeh_settings
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   log = logging.getLogger(__name__)
+docker_portal-web-1  |                   this_module = sys.modules[__name__]
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   BASE_DIR = os.path.dirname(__file__)
+docker_portal-web-1  |                   TETHYS_HOME = get_tethys_home_dir()
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   portal_config_settings = {}
+docker_portal-web-1  |                   try:
+docker_portal-web-1  |                       with open(os.path.join(TETHYS_HOME, 'portal_config.yml')) as portal_yaml:
+docker_portal-web-1  |                           portal_config_settings = yaml.safe_load(portal_yaml).get('settings', {}) or {}
+docker_portal-web-1  |                   except FileNotFoundError:
+docker_portal-web-1  |                       log.info('Could not find the portal_config.yml file. To generate a new portal_config.yml run the command '
+docker_portal-web-1  |                                '"tethys gen portal_config"')
+docker_portal-web-1  |                   except Exception:
+docker_portal-web-1  |                       log.exception('There was an error while attempting to read the settings from the portal_config.yml file.')
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   bokeh_settings.resources = portal_config_settings.pop('BOKEH_RESOURCES', 'cdn')
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Quick-start development settings - unsuitable for production
+docker_portal-web-1  |                   # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # SECURITY WARNING: keep the secret key used in production secret!
+docker_portal-web-1  |                   SECRET_KEY = portal_config_settings.pop('SECRET_KEY', generate_secret_key())
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # SECURITY WARNING: don't run with debug turned on in production!
+docker_portal-web-1  |                   DEBUG = portal_config_settings.pop('DEBUG', True)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   ALLOWED_HOSTS = portal_config_settings.pop('ALLOWED_HOSTS', [])
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # List those who should be notified of an error when DEBUG = False as a tuple of (name, email address).
+docker_portal-web-1  |                   # i.e.: ADMINS = (('John', 'john@example.com'), ('Mary', 'mary@example.com'))
+docker_portal-web-1  |                   ADMINS = portal_config_settings.pop('ADMINS', ())
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   TETHYS_PORTAL_CONFIG = portal_config_settings.pop('TETHYS_PORTAL_CONFIG', {})
+docker_portal-web-1  |                   # Use this setting to bypass the home page
+docker_portal-web-1  |                   BYPASS_TETHYS_HOME_PAGE = TETHYS_PORTAL_CONFIG.pop('BYPASS_TETHYS_HOME_PAGE', False)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Use this setting to disable open account signup
+docker_portal-web-1  |                   ENABLE_OPEN_SIGNUP = TETHYS_PORTAL_CONFIG.pop('ENABLE_OPEN_SIGNUP', False)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Set to True to allow Open Portal mode. This mode supersedes any specific user/group app access permissions
+docker_portal-web-1  |                   ENABLE_OPEN_PORTAL = TETHYS_PORTAL_CONFIG.pop('ENABLE_OPEN_PORTAL', False)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Set to True to allow Open Portal mode. This mode supersedes any specific user/group app access permissions
+docker_portal-web-1  |                   ENABLE_RESTRICTED_APP_ACCESS = TETHYS_PORTAL_CONFIG.pop('ENABLE_RESTRICTED_APP_ACCESS', False)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   SESSION_CONFIG = portal_config_settings.pop('SESSION_CONFIG', {})
+docker_portal-web-1  |                   # Force user logout once the browser has been closed.
+docker_portal-web-1  |                   # If changed, delete all django_session table entries from the tethys_default database to ensure updated behavior
+docker_portal-web-1  |                   SESSION_EXPIRE_AT_BROWSER_CLOSE = SESSION_CONFIG.pop('SESSION_EXPIRE_AT_BROWSER_CLOSE', True)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Warn user of forced logout after indicated number of seconds
+docker_portal-web-1  |                   SESSION_SECURITY_WARN_AFTER = SESSION_CONFIG.pop('SESSION_SECURITY_WARN_AFTER', 840)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Force user logout after a certain number of seconds
+docker_portal-web-1  |                   SESSION_SECURITY_EXPIRE_AFTER = SESSION_CONFIG.pop('SESSION_SECURITY_EXPIRE_AFTER', 900)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # add any additional SESSION_CONFIG settings
+docker_portal-web-1  |                   for setting, value in SESSION_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   DATABASES = portal_config_settings.pop('DATABASES', {})
+docker_portal-web-1  |                   DATABASES.setdefault('default', {'DIR': 'psql'})
+docker_portal-web-1  |                   DEFAULT_DB = DATABASES['default']
+docker_portal-web-1  |                   DEFAULT_DB.setdefault('ENGINE', 'django.db.backends.postgresql_psycopg2')
+docker_portal-web-1  |                   DEFAULT_DB.setdefault('NAME', 'tethys_platform')
+docker_portal-web-1  |                   DEFAULT_DB.setdefault('USER', 'tethys_default')
+docker_portal-web-1  |                   DEFAULT_DB.setdefault('PASSWORD', 'pass')
+docker_portal-web-1  |                   DEFAULT_DB.setdefault('HOST', 'localhost')
+docker_portal-web-1  |                   DEFAULT_DB.setdefault('PORT', 5436)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   LOGGING_CONFIG = portal_config_settings.pop('LOGGING_CONFIG', {})
+docker_portal-web-1  |                   # See https://docs.djangoproject.com/en/1.8/topics/logging/#configuring-logging for more logging configuration options.
+docker_portal-web-1  |                   LOGGING = portal_config_settings.pop('LOGGING', {})
+docker_portal-web-1  |                   LOGGING.setdefault('version', 1)
+docker_portal-web-1  |                   LOGGING.setdefault('disable_existing_loggers', False)
+docker_portal-web-1  |                   LOGGING.setdefault('formatters', {
+docker_portal-web-1  |                       'verbose': {
+docker_portal-web-1  |                           'format': '%(levelname)s:%(name)s:%(message)s'
+docker_portal-web-1  |                       },
+docker_portal-web-1  |                       'simple': {
+docker_portal-web-1  |                           'format': '%(levelname)s %(message)s'
+docker_portal-web-1  |                       },
+docker_portal-web-1  |                   })
+docker_portal-web-1  |                   LOGGING.setdefault('handlers', {
+docker_portal-web-1  |                       'console_simple': {
+docker_portal-web-1  |                           'class': 'logging.StreamHandler',
+docker_portal-web-1  |                           'formatter': 'simple'
+docker_portal-web-1  |                       },
+docker_portal-web-1  |                       'console_verbose': {
+docker_portal-web-1  |                           'class': 'logging.StreamHandler',
+docker_portal-web-1  |                           'formatter': 'verbose'
+docker_portal-web-1  |                       },
+docker_portal-web-1  |                   })
+docker_portal-web-1  |                   LOGGING.setdefault('loggers', {})
+docker_portal-web-1  |                   LOGGERS = LOGGING['loggers']
+docker_portal-web-1  |                   LOGGERS.setdefault('django', {
+docker_portal-web-1  |                       'handlers': ['console_simple'],
+docker_portal-web-1  |                       'level': os.getenv('DJANGO_LOG_LEVEL', 'WARNING'),
+docker_portal-web-1  |                   })
+docker_portal-web-1  |                   LOGGERS.setdefault('tethys', {
+docker_portal-web-1  |                       'handlers': ['console_verbose'],
+docker_portal-web-1  |                       'level': 'INFO',
+docker_portal-web-1  |                   })
+docker_portal-web-1  |                   LOGGERS.setdefault('tethys.apps', {
+docker_portal-web-1  |                       'handlers': ['console_verbose'],
+docker_portal-web-1  |                       'level': 'INFO',
+docker_portal-web-1  |                   })
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   INSTALLED_APPS = portal_config_settings.pop('INSTALLED_APPS_OVERRIDE', [
+docker_portal-web-1  |                       'django.contrib.admin',
+docker_portal-web-1  |                       'django.contrib.auth',
+docker_portal-web-1  |                       'django.contrib.contenttypes',
+docker_portal-web-1  |                       'django.contrib.sessions',
+docker_portal-web-1  |                       'django.contrib.messages',
+docker_portal-web-1  |                       'django.contrib.staticfiles',
+docker_portal-web-1  |                       'django_gravatar',
+docker_portal-web-1  |                       'bootstrap3',
+docker_portal-web-1  |                       'termsandconditions',
+docker_portal-web-1  |                       'tethys_config',
+docker_portal-web-1  |                       'tethys_apps',
+docker_portal-web-1  |                       'tethys_gizmos',
+docker_portal-web-1  |                       'tethys_services',
+docker_portal-web-1  |                       'tethys_compute',
+docker_portal-web-1  |                       'tethys_quotas',
+docker_portal-web-1  |                       'social_django',
+docker_portal-web-1  |                       'guardian',
+docker_portal-web-1  |                       'session_security',
+docker_portal-web-1  |                       'captcha',
+docker_portal-web-1  |                       'snowpenguin.django.recaptcha2',
+docker_portal-web-1  |                       'rest_framework',
+docker_portal-web-1  |                       'rest_framework.authtoken',
+docker_portal-web-1  |                       'analytical',
+docker_portal-web-1  |                       'channels',
+docker_portal-web-1  |                       'mfa',
+docker_portal-web-1  |                       'axes',
+docker_portal-web-1  |                   ])
+docker_portal-web-1  |                   INSTALLED_APPS = tuple(INSTALLED_APPS + portal_config_settings.pop('INSTALLED_APPS', []))
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   MIDDLEWARE = portal_config_settings.pop('MIDDLEWARE_OVERRIDE', [
+docker_portal-web-1  |                       'django.contrib.sessions.middleware.SessionMiddleware',
+docker_portal-web-1  |                       'django.middleware.common.CommonMiddleware',
+docker_portal-web-1  |                       'django.middleware.csrf.CsrfViewMiddleware',
+docker_portal-web-1  |                       'django.contrib.auth.middleware.AuthenticationMiddleware',
+docker_portal-web-1  |                       'django.contrib.messages.middleware.MessageMiddleware',
+docker_portal-web-1  |                       'tethys_portal.middleware.TethysMfaRequiredMiddleware',
+docker_portal-web-1  |                       'django.middleware.clickjacking.XFrameOptionsMiddleware',
+docker_portal-web-1  |                       'tethys_portal.middleware.TethysSocialAuthExceptionMiddleware',
+docker_portal-web-1  |                       'tethys_portal.middleware.TethysAppAccessMiddleware',
+docker_portal-web-1  |                       'session_security.middleware.SessionSecurityMiddleware',
+docker_portal-web-1  |                       'axes.middleware.AxesMiddleware',
+docker_portal-web-1  |                   ])
+docker_portal-web-1  |                   MIDDLEWARE = tuple(MIDDLEWARE + portal_config_settings.pop('MIDDLEWARE', []))
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   AUTHENTICATION_BACKENDS = portal_config_settings.pop('AUTHENTICATION_BACKENDS_OVERRIDE', [
+docker_portal-web-1  |                       'axes.backends.AxesBackend',
+docker_portal-web-1  |                       'django.contrib.auth.backends.ModelBackend',
+docker_portal-web-1  |                       'guardian.backends.ObjectPermissionBackend',
+docker_portal-web-1  |                   ])
+docker_portal-web-1  |                   AUTHENTICATION_BACKENDS = tuple(portal_config_settings.pop('AUTHENTICATION_BACKENDS', []) + AUTHENTICATION_BACKENDS)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   RESOURCE_QUOTA_HANDLERS = portal_config_settings.pop('RESOURCE_QUOTA_HANDLERS_OVERRIDE', [
+docker_portal-web-1  |                       "tethys_quotas.handlers.workspace.WorkspaceQuotaHandler",
+docker_portal-web-1  |                   ])
+docker_portal-web-1  |                   RESOURCE_QUOTA_HANDLERS = tuple(RESOURCE_QUOTA_HANDLERS + portal_config_settings.pop('RESOURCE_QUOTA_HANDLERS', []))
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   REST_FRAMEWORK = {
+docker_portal-web-1  |                       'DEFAULT_PERMISSION_CLASSES': (
+docker_portal-web-1  |                           'rest_framework.permissions.IsAuthenticated',
+docker_portal-web-1  |                       ),
+docker_portal-web-1  |                       'DEFAULT_AUTHENTICATION_CLASSES': (
+docker_portal-web-1  |                           'rest_framework.authentication.TokenAuthentication',
+docker_portal-web-1  |                       )
+docker_portal-web-1  |                   }
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Terms and conditions settings
+docker_portal-web-1  |                   ACCEPT_TERMS_PATH = '/terms/accept/'
+docker_portal-web-1  |                   TERMS_EXCLUDE_URL_PREFIX_LIST = {'/admin/', '/oauth2/', '/handoff/', '/accounts/', '/terms/'}
+docker_portal-web-1  |                   TERMS_EXCLUDE_URL_LIST = {'/'}
+docker_portal-web-1  |                   TERMS_BASE_TEMPLATE = 'page.html'
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   ROOT_URLCONF = 'tethys_portal.urls'
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Internationalization
+docker_portal-web-1  |                   # https://docs.djangoproject.com/en/1.9/topics/i18n/
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   LANGUAGE_CODE = 'en-us'
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   TIME_ZONE = 'UTC'
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   USE_I18N = True
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   USE_L10N = True
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   USE_TZ = True
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Templates
+docker_portal-web-1  |                   TEMPLATES = [
+docker_portal-web-1  |                       {
+docker_portal-web-1  |                           'BACKEND': 'django.template.backends.django.DjangoTemplates',
+docker_portal-web-1  |                           'DIRS': [
+docker_portal-web-1  |                               os.path.join(BASE_DIR, 'templates'),
+docker_portal-web-1  |                           ],
+docker_portal-web-1  |                           'OPTIONS': {
+docker_portal-web-1  |                               'context_processors': [
+docker_portal-web-1  |                                   'django.contrib.auth.context_processors.auth',
+docker_portal-web-1  |                                   'django.template.context_processors.debug',
+docker_portal-web-1  |                                   'django.template.context_processors.i18n',
+docker_portal-web-1  |                                   'django.template.context_processors.media',
+docker_portal-web-1  |                                   'django.template.context_processors.static',
+docker_portal-web-1  |                                   'django.template.context_processors.tz',
+docker_portal-web-1  |                                   'django.template.context_processors.request',
+docker_portal-web-1  |                                   'django.contrib.messages.context_processors.messages',
+docker_portal-web-1  |                                   'social_django.context_processors.backends',
+docker_portal-web-1  |                                   'social_django.context_processors.login_redirect',
+docker_portal-web-1  |                                   'tethys_config.context_processors.tethys_global_settings_context',
+docker_portal-web-1  |                                   'tethys_apps.context_processors.tethys_apps_context',
+docker_portal-web-1  |                                   'tethys_gizmos.context_processors.tethys_gizmos_context'
+docker_portal-web-1  |                               ],
+docker_portal-web-1  |                               'loaders': [
+docker_portal-web-1  |                                   'django.template.loaders.filesystem.Loader',
+docker_portal-web-1  |                                   'django.template.loaders.app_directories.Loader',
+docker_portal-web-1  |                                   'tethys_apps.template_loaders.TethysTemplateLoader'
+docker_portal-web-1  |                               ],
+docker_portal-web-1  |                               'debug': DEBUG
+docker_portal-web-1  |                           }
+docker_portal-web-1  |                       }
+docker_portal-web-1  |                   ]
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Static files (CSS, JavaScript, Images)
+docker_portal-web-1  |                   # https://docs.djangoproject.com/en/1.9/howto/static-files/
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   STATIC_URL = '/static/'
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   STATICFILES_DIRS = (os.path.join(BASE_DIR, 'static'),)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   STATICFILES_FINDERS = (
+docker_portal-web-1  |                       'django.contrib.staticfiles.finders.FileSystemFinder',
+docker_portal-web-1  |                       'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+docker_portal-web-1  |                       'tethys_apps.static_finders.TethysStaticFinder'
+docker_portal-web-1  |                   )
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   STATIC_ROOT = TETHYS_PORTAL_CONFIG.pop('STATIC_ROOT', os.path.join(TETHYS_HOME, 'static'))
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   TETHYS_WORKSPACES_ROOT = TETHYS_PORTAL_CONFIG.pop('TETHYS_WORKSPACES_ROOT', os.path.join(TETHYS_HOME, 'workspaces'))
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # add any additional TETHYS_PORTAL_CONFIG settings
+docker_portal-web-1  |                   for setting, value in TETHYS_PORTAL_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Messaging settings
+docker_portal-web-1  |                   MESSAGE_TAGS = {
+docker_portal-web-1  |                       message_constants.DEBUG: 'alert-danger',
+docker_portal-web-1  |                       message_constants.INFO: 'alert-info',
+docker_portal-web-1  |                       message_constants.SUCCESS: 'alert-success',
+docker_portal-web-1  |                       message_constants.WARNING: 'alert-warning',
+docker_portal-web-1  |                       message_constants.ERROR: 'alert-danger'
+docker_portal-web-1  |                   }
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Email Configuration
+docker_portal-web-1  |                   EMAIL_CONFIG = portal_config_settings.pop('EMAIL_CONFIG', {})
+docker_portal-web-1  |                   EMAIL_FROM = portal_config_settings.pop('EMAIL_FROM', '')
+docker_portal-web-1  |                   for setting, value in EMAIL_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Gravatar Settings
+docker_portal-web-1  |                   GRAVATAR_URL = 'http://www.gravatar.com/'
+docker_portal-web-1  |                   GRAVATAR_SECURE_URL = 'https://secure.gravatar.com/'
+docker_portal-web-1  |                   GRAVATAR_DEFAULT_SIZE = '80'
+docker_portal-web-1  |                   GRAVATAR_DEFAULT_IMAGE = 'retro'
+docker_portal-web-1  |                   GRAVATAR_DEFAULT_RATING = 'g'
+docker_portal-web-1  |                   GRAVATAR_DFFAULT_SECURE = True
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # OAuth Settings
+docker_portal-web-1  |                   # http://psa.matiasaguirre.net/docs/configuration/index.html
+docker_portal-web-1  |                   SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['username', 'first_name', 'email']
+docker_portal-web-1  |                   SOCIAL_AUTH_SLUGIFY_USERNAMES = True
+docker_portal-web-1  |                   SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/apps/'
+docker_portal-web-1  |                   SOCIAL_AUTH_LOGIN_ERROR_URL = '/accounts/login/'
+docker_portal-web-1  |                   SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = ['tenant']
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # OAuth Providers
+docker_portal-web-1  |                   OAUTH_CONFIG = portal_config_settings.pop('OAUTH_CONFIG', {})
+docker_portal-web-1  |                   for setting, value in OAUTH_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # MFA Settings
+docker_portal-web-1  |                   # See: https://github.com/mkalioby/django-mfa2
+docker_portal-web-1  |                   # Methods that shouldn't be allowed for the user, U2F, FIDO2, TOTP, Trusted_Devices, Email
+docker_portal-web-1  |                   MFA_REQUIRED = False                # Require all users to set up MFA
+docker_portal-web-1  |                   SSO_MFA_REQUIRED = False            # Require users logged in with SSO to set up MFA when MFA_REQUIRED is True
+docker_portal-web-1  |                   ADMIN_MFA_REQUIRED = True           # Require admin users to set up MFA when MFA_REQUIRED is True
+docker_portal-web-1  |                   MFA_UNALLOWED_METHODS = ('U2F', 'FIDO2', 'Email', 'Trusted_Devices')
+docker_portal-web-1  |                   # A function that should be called by username to login the user in session
+docker_portal-web-1  |                   MFA_LOGIN_CALLBACK = 'tethys_portal.utilities.log_user_in'
+docker_portal-web-1  |                   MFA_RECHECK = False                  # Allow random rechecking of the user
+docker_portal-web-1  |                   MFA_RECHECK_MIN = 600                # Minimum interval in seconds
+docker_portal-web-1  |                   MFA_RECHECK_MAX = 1800               # Maximum in seconds
+docker_portal-web-1  |                   MFA_QUICKLOGIN = False               # Allow quick login for returning users by provide only their 2FA
+docker_portal-web-1  |                   MFA_HIDE_DISABLE = ('FIDO2',)        # Can the user disable his key (Added in 1.2.0).
+docker_portal-web-1  |                   MFA_OWNED_BY_ENTERPRISE = False      # Who owns security keys
+docker_portal-web-1  |                   TOKEN_ISSUER_NAME = 'Tethys Portal'  # TOTP Issuer name
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   U2F_APPID = 'http://localhost'       # URL For U2F
+docker_portal-web-1  |                   FIDO_SERVER_ID = u'localhost'        # Server rp id for FIDO2, it's the full domain of your project
+docker_portal-web-1  |                   FIDO_SERVER_NAME = u'Tethys Portal'
+docker_portal-web-1  |                   FIDO_LOGIN_URL = '/auth/login'
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   MFA_CONFIG = portal_config_settings.pop('MFA_CONFIG', {})
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   for setting, value in MFA_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Lockout Configuration
+docker_portal-web-1  |                   AXES_ENABLED = not DEBUG
+docker_portal-web-1  |                   AXES_FAILURE_LIMIT = 3
+docker_portal-web-1  |                   AXES_COOLOFF_TIME = dt.timedelta(hours=0.5)
+docker_portal-web-1  |                   AXES_ONLY_USER_FAILURES = True
+docker_portal-web-1  |                   AXES_ENABLE_ADMIN = True
+docker_portal-web-1  |                   AXES_LOCKOUT_TEMPLATE = 'tethys_portal/accounts/lockout.html'
+docker_portal-web-1  |                   AXES_VERBOSE = True
+docker_portal-web-1  |                   AXES_RESET_ON_SUCCESS = True
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   LOCKOUT_CONFIG = portal_config_settings.pop('LOCKOUT_CONFIG', {})
+docker_portal-web-1  |                   for setting, value in LOCKOUT_CONFIG.items():
+docker_portal-web-1  |                       if setting == 'AXES_COOLOFF_TIME' and isinstance(value, str):
+docker_portal-web-1  |                           import isodate
+docker_portal-web-1  |                           try:
+docker_portal-web-1  |                               value = isodate.parse_duration(value)
+docker_portal-web-1  |                           except Exception:
+docker_portal-web-1  |                               pass
+docker_portal-web-1  |                   
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Django Guardian Settings
+docker_portal-web-1  |                   ANONYMOUS_USER_ID = -1
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   CAPTCHA_CONFIG = portal_config_settings.pop('CAPTCHA_CONFIG', {})
+docker_portal-web-1  |                   for setting, value in CAPTCHA_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   # If you require reCaptcha to be loaded from somewhere other than https://google.com
+docker_portal-web-1  |                   # (e.g. to bypass firewall restrictions), you can specify what proxy to use.
+docker_portal-web-1  |                   # RECAPTCHA_PROXY_HOST: https://recaptcha.net
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Placeholders for the ID's required by various web-analytics services supported by Django-Analytical.
+docker_portal-web-1  |                   # Replace False with the tracking ID as a string e.g. SERVICE_ID = 'abcd1234'
+docker_portal-web-1  |                   ANALYTICS_CONFIG = portal_config_settings.pop('ANALYTICS_CONFIG', {})
+docker_portal-web-1  |                   for setting, value in ANALYTICS_CONFIG.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   ASGI_APPLICATION = "tethys_portal.routing.application"
+docker_portal-web-1  |                   
+docker_portal-web-1  |                   # Add any additional specified settings to module
+docker_portal-web-1  |                   for setting, value in portal_config_settings.items():
+docker_portal-web-1  |                       setattr(this_module, setting, value)
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Persist_NGINX_Config_Post_App
+docker_portal-web-1  |     Function: file.rename
+docker_portal-web-1  |         Name: /var/lib/tethys_persist/tethys_nginx.conf
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Moved "/usr/lib/tethys/tethys_nginx.conf" to "/var/lib/tethys_persist/tethys_nginx.conf"
+docker_portal-web-1  |      Started: 20:43:09.928314
+docker_portal-web-1  |     Duration: 17.312 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               /var/lib/tethys_persist/tethys_nginx.conf:
+docker_portal-web-1  |                   /usr/lib/tethys/tethys_nginx.conf
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Link_NGINX_Config_Post_App
+docker_portal-web-1  |     Function: file.symlink
+docker_portal-web-1  |         Name: /etc/nginx/sites-enabled/tethys_nginx.conf
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Created new symlink /etc/nginx/sites-enabled/tethys_nginx.conf -> /var/lib/tethys_persist/tethys_nginx.conf
+docker_portal-web-1  |      Started: 20:43:09.945852
+docker_portal-web-1  |     Duration: 1.781 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               new:
+docker_portal-web-1  |                   /etc/nginx/sites-enabled/tethys_nginx.conf
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Persist_NGINX_Supervisor_Post_App
+docker_portal-web-1  |     Function: file.rename
+docker_portal-web-1  |         Name: /var/lib/tethys_persist/nginx_supervisord.conf
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Moved "/usr/lib/tethys/nginx_supervisord.conf" to "/var/lib/tethys_persist/nginx_supervisord.conf"
+docker_portal-web-1  |      Started: 20:43:09.947733
+docker_portal-web-1  |     Duration: 15.044 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               /var/lib/tethys_persist/nginx_supervisord.conf:
+docker_portal-web-1  |                   /usr/lib/tethys/nginx_supervisord.conf
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Link_NGINX_Supervisor_Post_App
+docker_portal-web-1  |     Function: file.symlink
+docker_portal-web-1  |         Name: /etc/supervisor/conf.d/nginx_supervisord.conf
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Created new symlink /etc/supervisor/conf.d/nginx_supervisord.conf -> /var/lib/tethys_persist/nginx_supervisord.conf
+docker_portal-web-1  |      Started: 20:43:09.963074
+docker_portal-web-1  |     Duration: 2.103 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               new:
+docker_portal-web-1  |                   /etc/supervisor/conf.d/nginx_supervisord.conf
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Persist_ASGI_Supervisor_Post_App
+docker_portal-web-1  |     Function: file.rename
+docker_portal-web-1  |         Name: /var/lib/tethys_persist/asgi_supervisord.conf
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Moved "/usr/lib/tethys/asgi_supervisord.conf" to "/var/lib/tethys_persist/asgi_supervisord.conf"
+docker_portal-web-1  |      Started: 20:43:09.965320
+docker_portal-web-1  |     Duration: 15.868 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               /var/lib/tethys_persist/asgi_supervisord.conf:
+docker_portal-web-1  |                   /usr/lib/tethys/asgi_supervisord.conf
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Link_ASGI_Supervisor_Post_App
+docker_portal-web-1  |     Function: file.symlink
+docker_portal-web-1  |         Name: /etc/supervisor/conf.d/asgi_supervisord.conf
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Created new symlink /etc/supervisor/conf.d/asgi_supervisord.conf -> /var/lib/tethys_persist/asgi_supervisord.conf
+docker_portal-web-1  |      Started: 20:43:09.981376
+docker_portal-web-1  |     Duration: 1.419 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               new:
+docker_portal-web-1  |                   /etc/supervisor/conf.d/asgi_supervisord.conf
+docker_portal-web-1  | ----------
+docker_portal-web-1  |           ID: Tethys_Persist_Permissions
+docker_portal-web-1  |     Function: cmd.run
+docker_portal-web-1  |         Name: chown -R www: /var/lib/tethys_persist && chmod -R g+rw /var/lib/tethys_persist
+docker_portal-web-1  |       Result: True
+docker_portal-web-1  |      Comment: Command "chown -R www: /var/lib/tethys_persist && chmod -R g+rw /var/lib/tethys_persist" run
+docker_portal-web-1  |      Started: 20:43:09.982894
+docker_portal-web-1  |     Duration: 10.748 ms
+docker_portal-web-1  |      Changes:   
+docker_portal-web-1  |               ----------
+docker_portal-web-1  |               pid:
+docker_portal-web-1  |                   478
+docker_portal-web-1  |               retcode:
+docker_portal-web-1  |                   0
+docker_portal-web-1  |               stderr:
+docker_portal-web-1  |               stdout:
+docker_portal-web-1  | 
+docker_portal-web-1  | Summary for local
+docker_portal-web-1  | -------------
+docker_portal-web-1  | Succeeded: 27 (changed=37)
+docker_portal-web-1  | Failed:    11
+docker_portal-web-1  | -------------
+docker_portal-web-1  | Total states run:     38
+docker_portal-web-1  | Total run time:   58.756 s
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | - Fixing permissions
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | - Starting supervisor
+docker_portal-web-1  | tput: No value for $TERM and no -T specified
+docker_portal-web-1  | /usr/lib/python3/dist-packages/supervisor/options.py:474: UserWarning: Supervisord is running as root and it is searching for its configuration file in default locations (including its current working directory); you probably want to specify a "-c" argument specifying an absolute path to a configuration file for improved security.
+docker_portal-web-1  |   self.warnings.warn(
+docker_portal-web-1  | 2022-03-10 20:43:10,691 WARN For [program:nginx], redirect_stderr=true but stderr_logfile has also been set to a filename, the filename has been ignored
+docker_portal-web-1  | 2022-03-10 20:43:10,692 INFO Included extra file "/etc/supervisor/conf.d/asgi_supervisord.conf" during parsing
+docker_portal-web-1  | 2022-03-10 20:43:10,692 INFO Included extra file "/etc/supervisor/conf.d/nginx_supervisord.conf" during parsing
+docker_portal-web-1  | 2022-03-10 20:43:10,692 INFO Set uid to user 1011 succeeded
+docker_portal-web-1  | 2022-03-10 20:43:10,694 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:10,694 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:10,696 INFO RPC interface 'supervisor' initialized
+docker_portal-web-1  | 2022-03-10 20:43:10,696 CRIT Server 'unix_http_server' running without any HTTP authentication checking
+docker_portal-web-1  | 2022-03-10 20:43:10,697 INFO supervisord started with pid 557
+docker_portal-web-1  | 2022-03-10 20:43:11,698 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:11,705 INFO spawned: 'tethys_asgi0' with pid 558
+docker_portal-web-1  | 2022-03-10 20:43:11,718 INFO spawned: 'nginx' with pid 559
+docker_portal-web-1  | 2022-03-10 20:43:12,747 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:12,748 INFO success: nginx entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:14,346 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:14,347 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:15,348 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:15,354 INFO spawned: 'tethys_asgi0' with pid 584
+docker_portal-web-1  | 2022-03-10 20:43:16,358 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:17,712 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:17,712 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:18,713 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:18,716 INFO spawned: 'tethys_asgi0' with pid 607
+docker_portal-web-1  | 2022-03-10 20:43:19,718 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:21,169 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:21,169 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:22,171 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:22,177 INFO spawned: 'tethys_asgi0' with pid 624
+docker_portal-web-1  | 2022-03-10 20:43:23,181 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:24,646 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:24,646 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:25,648 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:25,654 INFO spawned: 'tethys_asgi0' with pid 641
+docker_portal-web-1  | 2022-03-10 20:43:26,657 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:27,931 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:27,931 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:28,933 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:28,935 INFO spawned: 'tethys_asgi0' with pid 658
+docker_portal-web-1  | 2022-03-10 20:43:29,937 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:31,350 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:31,350 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:32,351 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:32,357 INFO spawned: 'tethys_asgi0' with pid 675
+docker_portal-web-1  | 2022-03-10 20:43:33,361 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:34,774 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:34,774 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:35,774 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:35,781 INFO spawned: 'tethys_asgi0' with pid 692
+docker_portal-web-1  | 2022-03-10 20:43:36,785 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:38,086 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:38,086 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:39,087 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:39,090 INFO spawned: 'tethys_asgi0' with pid 709
+docker_portal-web-1  | 2022-03-10 20:43:40,092 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:41,604 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:41,604 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:42,606 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:42,612 INFO spawned: 'tethys_asgi0' with pid 726
+docker_portal-web-1  | 2022-03-10 20:43:43,616 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:45,013 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:45,013 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:46,015 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:46,017 INFO spawned: 'tethys_asgi0' with pid 743
+docker_portal-web-1  | 2022-03-10 20:43:47,019 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:48,201 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:48,201 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:49,202 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:49,204 INFO spawned: 'tethys_asgi0' with pid 766
+docker_portal-web-1  | 2022-03-10 20:43:50,206 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:51,699 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:51,699 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:52,701 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:52,707 INFO spawned: 'tethys_asgi0' with pid 783
+docker_portal-web-1  | 2022-03-10 20:43:53,711 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:55,098 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:55,099 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:56,100 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:56,103 INFO spawned: 'tethys_asgi0' with pid 800
+docker_portal-web-1  | 2022-03-10 20:43:57,105 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:43:58,312 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:43:58,312 INFO Closing socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:59,314 INFO Creating socket tcp://127.0.0.1:8000
+docker_portal-web-1  | 2022-03-10 20:43:59,316 INFO spawned: 'tethys_asgi0' with pid 817
+docker_portal-web-1  | 2022-03-10 20:44:00,318 INFO success: tethys_asgi0 entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+docker_portal-web-1  | 2022-03-10 20:44:01,863 INFO exited: tethys_asgi0 (exit status 1; not expected)
+docker_portal-web-1  | 2022-03-10 20:44:01,863 INFO Closing socket tcp://127.0.0.1:8000


### PR DESCRIPTION
@romer8 here are my changes.

### Tethys Image:
Use `FROM tethysplatform/tethys-core:3.4.1` instead of `FROM tethysplatform/tethys-core:master`

### Database:

You set the db to `postgres` which defaults to `latest`. I don't know if Tethys works with postgres:14 yet. In these changes I set the db to `postgis/postgis:latest`, but I think setting it to `postgres:12` or `postgres:13` would work too if you don't want/need postgis. 

### Custom run script:

I'm assuming the `final_run.sh` and related artifacts are from you trying to debug issues with using postgres:14, so I removed/commented those out in the dockerfile.

### Current Issue:

Getting past the database version issue revealed another issue. Settings aren't getting set right because of a quote escaping issue with the `web.env` file:

docker_portal-web-1  | ----------
docker_portal-web-1  |           ID: Generate_Tethys_Settings_TethysCore
docker_portal-web-1  |     Function: cmd.run
docker_portal-web-1  |         Name: /opt/conda/envs/tethys/bin/tethys settings --set DEBUG False --set ALLOWED_HOSTS "[localhost, 127.0.0.1]\ --set DATABASES.default.NAME tethys_platform --set DATABASES.default.USER tethys_default --set DATABASES.default.PASSWORD pass --set DATABASES.default.HOST db --set DATABASES.default.PORT 5432 --set INSTALLED_APPS "[]" --set SESSION_CONFIG.SECURITY_WARN_AFTER 1500 --set SESSION_CONFIG.SECURITY_EXPIRE_AFTER 1800 --set TETHYS_PORTAL_CONFIG.STATIC_ROOT /var/lib/tethys_persist/static --set TETHYS_PORTAL_CONFIG.TETHYS_WORKSPACES_ROOT /var/lib/tethys_persist/workspaces --set RESOURCE_QUOTA_HANDLERS "[]" --set ANALYTICS_CONFIG "{}" --set AUTHENTICATION_BACKENDS "[]" --set OAUTH_CONFIG "{}" --set CHANNEL_LAYERS.default.BACKEND channels_redis.core.RedisChannelLayer --set CHANNEL_LAYERS.default.CONFIG "{"hosts":[["redis",6379]]}\ --set CAPTCHA_CONFIG.RECAPTCHA_PRIVATE_KEY '' --set CAPTCHA_CONFIG.RECAPTCHA_PUBLIC_KEY ''
docker_portal-web-1  | 
docker_portal-web-1  |       Result: False
docker_portal-web-1  |      Comment: Command "/opt/conda/envs/tethys/bin/tethys settings --set DEBUG False --set ALLOWED_HOSTS "[localhost, 127.0.0.1]\ --set DATABASES.default.NAME tethys_platform --set DATABASES.default.USER tethys_default --set DATABASES.default.PASSWORD pass --set DATABASES.default.HOST db --set DATABASES.default.PORT 5432 --set INSTALLED_APPS "[]" --set SESSION_CONFIG.SECURITY_WARN_AFTER 1500 --set SESSION_CONFIG.SECURITY_EXPIRE_AFTER 1800 --set TETHYS_PORTAL_CONFIG.STATIC_ROOT /var/lib/tethys_persist/static --set TETHYS_PORTAL_CONFIG.TETHYS_WORKSPACES_ROOT /var/lib/tethys_persist/workspaces --set RESOURCE_QUOTA_HANDLERS "[]" --set ANALYTICS_CONFIG "{}" --set AUTHENTICATION_BACKENDS "[]" --set OAUTH_CONFIG "{}" --set CHANNEL_LAYERS.default.BACKEND channels_redis.core.RedisChannelLayer --set CHANNEL_LAYERS.default.CONFIG "{"hosts":[["redis",6379]]}\ --set CAPTCHA_CONFIG.RECAPTCHA_PRIVATE_KEY '' --set CAPTCHA_CONFIG.RECAPTCHA_PUBLIC_KEY ''
docker_portal-web-1  |               " run
docker_portal-web-1  |      Started: 20:42:13.900614
docker_portal-web-1  |     Duration: 2724.905 ms
docker_portal-web-1  |      Changes:   
docker_portal-web-1  |               ----------
docker_portal-web-1  |               pid:
docker_portal-web-1  |                   123
docker_portal-web-1  |               retcode:
docker_portal-web-1  |                   2
docker_portal-web-1  |               stderr:
docker_portal-web-1  |                   usage: tethys [-h]
docker_portal-web-1  |                                 {version,app_settings,db,docker,gen,install,uninstall,link,list,manage,scaffold,schedulers,services,settings,site,syncstores,test}
docker_portal-web-1  |                                 ...
docker_portal-web-1  |                   tethys: error: unrecognized arguments: CAPTCHA_CONFIG.RECAPTCHA_PRIVATE_KEY
docker_portal-web-1  |               stdout:
docker_portal-web-1  | ----------

Notice that this part of the command is missing a quote at the end: 

```
tethys settings --set DEBUG False --set ALLOWED_HOSTS "[localhost, 127.0.0.1]\ 
```

I tried lots of different ways to escape or add quotes and I couldn't figure it out. Those values are set in the `web.env` file. I think it would work you figured out the quote escaping thing. It's also later on in the command here:

```
--set CHANNEL_LAYERS.default.CONFIG "{"hosts":[["redis",6379]]}\ 
```

This is causing all the settings, including the database settings, to not be set properly. I was not having this problem when I wrote the tutorial, so I'm not sure what changed.

